### PR TITLE
fix(factory): deterministic git-push auth + fail-loud PR/push verify

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -75,7 +75,28 @@ const issueTitle = execFileSync(
 // copyToWorktree node_modules — pnpm's symlinked store breaks across the
 // host->worktree bind-mount).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth DETERMINISTICALLY inside the container.
+      //
+      // ROOT CAUSE: @ai-hero/sandcastle@0.12.0 only configures git
+      // `safe.directory` + `user.name`/`user.email` in the sandbox — it does
+      // NO credential setup (verified in dist: `withSandboxLifecycle`). `gh`
+      // authenticates from GH_TOKEN, but a bare `git push` uses git's own
+      // credential system, which is not wired to the token. Pushes therefore
+      // succeed only by luck (relay#70) and fail silently otherwise (store#50).
+      //
+      // `gh auth setup-git` installs `gh` as git's credential helper for
+      // github.com in the container-global gitconfig, so every subsequent
+      // `git push` reuses GH_TOKEN. The helper stores NO token in any file — it
+      // shells out to `gh auth git-credential`, which reads GH_TOKEN at push
+      // time. Guarded on GH_TOKEN so local dev without a token no-ops instead
+      // of aborting sandbox setup (onSandboxReady failures are fatal). This is
+      // the FIRST hook so auth is in place before anything else runs.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 console.log(
@@ -89,6 +110,12 @@ console.log(
 // ---------------------------------------------------------------------------
 // Implement -> Review -> (open PR | merge)
 // ---------------------------------------------------------------------------
+
+// Set to a non-null message in the PR-verification step below when the open-pr
+// phase reported success but no PR actually landed. We record it here (rather
+// than calling process.exit inside the try) so the `finally` still closes the
+// sandbox before we fail the job non-zero.
+let openPrVerificationError: string | null = null;
 
 const sandbox = await sandcastle.createSandbox({
   branch,
@@ -165,10 +192,68 @@ try {
         BRANCH: branch,
       },
     });
-    console.log("\nPR opened (or already existed). Awaiting human review.");
+    // FAIL LOUD. The open-pr phase logs COMPLETE from the prompt regardless of
+    // whether the in-sandbox `git push` / `gh pr create` actually succeeded, so
+    // we must NOT trust it. Verify from the HOST (whose `gh` is authenticated
+    // via GH_TOKEN) that an OPEN PR now exists for this branch. If not, dump the
+    // push/PR state and exit non-zero so the Actions job FAILS instead of
+    // green-lying (store#50: implementer committed, but push failed silently and
+    // no PR was ever created, yet the job went green).
+    const openPrs = JSON.parse(
+      execFileSync(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "open", "--json", "number,url"],
+        { encoding: "utf8" },
+      ),
+    ) as Array<{ number: number; url: string }>;
+
+    if (openPrs.length > 0) {
+      const pr = openPrs[0]!;
+      console.log(`\nVerified: PR #${pr.number} is open — ${pr.url}`);
+      console.log("Awaiting human review.");
+    } else {
+      // No open PR. Gather diagnostics (all via the authenticated host `gh`).
+      const nwo = execFileSync(
+        "gh",
+        ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        { encoding: "utf8" },
+      ).trim();
+
+      let branchPushed = false;
+      try {
+        execFileSync("gh", ["api", `repos/${nwo}/git/ref/heads/${branch}`], {
+          stdio: "pipe",
+        });
+        branchPushed = true;
+      } catch {
+        branchPushed = false;
+      }
+
+      const anyStatePrs = execFileSync(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,url"],
+        { encoding: "utf8" },
+      ).trim();
+
+      openPrVerificationError =
+        `\nERROR: the open-pr phase reported COMPLETE, but no OPEN PR exists ` +
+        `for branch '${branch}'.\n` +
+        `  Remote branch pushed to origin: ${branchPushed}\n` +
+        `  PRs for this branch (any state): ${anyStatePrs}\n` +
+        `  The in-sandbox \`git push\` and/or \`gh pr create\` failed ` +
+        `silently. Inspect the open-pr phase logs above. The Actions job is ` +
+        `failing deliberately so this is not mistaken for success.`;
+    }
   }
 } finally {
   await sandbox.close();
+}
+
+// Fail loud AFTER the sandbox is closed: a silently-failed push/PR-create must
+// turn the Actions job red, never green.
+if (openPrVerificationError) {
+  console.error(openPrVerificationError);
+  process.exit(1);
 }
 
 console.log("\nDone.");

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -55,13 +55,50 @@ if (!headRef) {
   throw new Error(`Could not resolve head branch for PR #${prNumber}.`);
 }
 
+// Read origin's tip SHA for a branch via the authenticated host `gh`. Returns
+// null if the ref does not exist or the lookup fails. Used to prove the
+// review-push actually advanced the PR branch (fail-loud verification below).
+function readRemoteHead(nwo: string, ref: string): string | null {
+  try {
+    return (
+      execFileSync(
+        "gh",
+        ["api", `repos/${nwo}/git/ref/heads/${ref}`, "--jq", ".object.sha"],
+        { encoding: "utf8" },
+      ).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+// rig is a pnpm workspace: install with the committed lockfile (mirrors
+// main.ts). We do NOT copyToWorktree node_modules (pnpm's symlinked store
+// breaks across the host->worktree bind-mount).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container (FIRST hook).
+      // The engine (@ai-hero/sandcastle@0.12.0) sets git identity + safe.directory
+      // but NO credential helper, so the review-push step's bare `git push` to the
+      // PR branch is unauthenticated and succeeds only by luck. `gh auth setup-git`
+      // installs `gh` as git's credential helper (reads GH_TOKEN at push time,
+      // stores no token in any file). Guarded on GH_TOKEN so token-less local dev
+      // no-ops. See ./agent-implement-issue.ts for the full note.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 console.log(
   `\n=== agent:review runner — PR #${prNumber} (head: ${headRef}) ===\n`,
 );
+
+// Set to a non-null message below if the review-push phase reported success but
+// the PR branch never advanced. Recorded here so the `finally` still closes the
+// sandbox before we fail the job non-zero.
+let reviewPushError: string | null = null;
 
 const sandbox = await sandcastle.createSandbox({
   branch: headRef,
@@ -82,6 +119,15 @@ try {
   });
 
   if (review.commits.length > 0) {
+    // Capture origin's PR-branch tip BEFORE the push so we can prove the push
+    // landed. `gh` on the host is authenticated via GH_TOKEN.
+    const nwo = execFileSync(
+      "gh",
+      ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+      { encoding: "utf8" },
+    ).trim();
+    const remoteHeadBefore = readRemoteHead(nwo, headRef);
+
     // Push the reviewer's refinement commits back onto the PR branch. No merge,
     // no close, no new PR — the existing PR just gets updated.
     console.log(
@@ -94,6 +140,28 @@ try {
       promptFile: "./.sandcastle/review-push-prompt.md",
       promptArgs: { BRANCH: headRef },
     });
+
+    // FAIL LOUD. review-push-prompt.md outputs COMPLETE regardless of whether the
+    // in-sandbox `git push` actually landed. Verify from the HOST that origin's
+    // PR-branch tip advanced past what it was before the push. If it did not, the
+    // reviewer's commits never reached the PR — exit non-zero so the Actions job
+    // fails instead of green-lying (store#50 class of silent-push bug).
+    const remoteHeadAfter = readRemoteHead(nwo, headRef);
+    if (remoteHeadAfter && remoteHeadAfter !== remoteHeadBefore) {
+      console.log(
+        `\nVerified: PR branch '${headRef}' advanced to ${remoteHeadAfter} — ` +
+          `the open PR picked up the review commits.`,
+      );
+    } else {
+      reviewPushError =
+        `\nERROR: the review-push phase reported COMPLETE, but origin/'${headRef}' ` +
+        `did not advance (before=${remoteHeadBefore ?? "<none>"}, ` +
+        `after=${remoteHeadAfter ?? "<none>"}).\n` +
+        `  The reviewer made ${review.commits.length} commit(s) that never ` +
+        `reached the PR — the in-sandbox \`git push\` failed silently. Inspect ` +
+        `the push-review phase logs above. The Actions job is failing ` +
+        `deliberately so this is not mistaken for success.`;
+    }
   } else {
     console.log(
       "\nReviewer made no changes — the code was already clean. Nothing to push.",
@@ -101,6 +169,13 @@ try {
   }
 } finally {
   await sandbox.close();
+}
+
+// Fail loud AFTER the sandbox is closed: a silently-failed review push must turn
+// the Actions job red, never green.
+if (reviewPushError) {
+  console.error(reviewPushError);
+  process.exit(1);
 }
 
 console.log("\nReview complete. The PR was NOT merged — a human still merges.");

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -55,7 +55,20 @@ const MAX_ITERATIONS = 10;
 // sandbox resolves the exact dependency tree. This replaces the template's
 // default `npm install` (rig does not use npm).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container. The engine
+      // (@ai-hero/sandcastle@0.12.0) configures git identity + safe.directory
+      // but NO credential helper, so a bare `git push` is unauthenticated and
+      // only succeeds by luck. `gh auth setup-git` installs `gh` as git's
+      // credential helper (reads GH_TOKEN at push time, stores no token in any
+      // file). Guarded on GH_TOKEN so token-less local dev no-ops rather than
+      // aborting setup. FIRST hook so auth precedes install. See
+      // ./agent-implement-issue.ts for the full note.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 // NOTE: the stock template copies the host `node_modules` into the worktree

--- a/.sandcastle/open-pr-prompt.md
+++ b/.sandcastle/open-pr-prompt.md
@@ -15,18 +15,33 @@ issue.** A human reviews and merges the PR.
    If there are no commits ahead of `main`, output `<promise>COMPLETE</promise>`
    and stop — there is nothing to open a PR for.
 
-2. Push the branch to origin:
+2. Wire `git push` authentication so the push below is NOT unauthenticated.
+   `gh` is authenticated from `GH_TOKEN`, but a bare `git push` uses git's own
+   credential system. Install `gh` as git's credential helper (idempotent; the
+   onSandboxReady hook already did this, but re-run it here so this step is
+   self-contained):
+
+   `gh auth setup-git`
+
+3. Push the branch to origin, then CONFIRM the remote ref actually exists — a
+   push can fail without an obvious error:
 
    `git push -u origin {{BRANCH}}`
+   `git ls-remote --heads origin {{BRANCH}}`
 
-3. Check whether a PR for this branch already exists:
+   If `git ls-remote` prints NO line for `{{BRANCH}}`, the push FAILED. Do
+   **not** output `<promise>COMPLETE</promise>`. Instead print the push error
+   and stop — the runner will detect the missing PR and fail the job.
+
+4. Check whether a PR for this branch already exists:
 
    `gh pr list --head {{BRANCH}} --state open --json number --jq '.[].number'`
 
-   - If one already exists, leave it as-is (do not open a duplicate) and stop.
-   - Otherwise open a new PR (step 4).
+   - If one already exists, leave it as-is (do not open a duplicate) and go to
+     step 6 to verify.
+   - Otherwise open a new PR (step 5).
 
-4. Open the PR:
+5. Open the PR:
 
    ```
    gh pr create \
@@ -46,10 +61,22 @@ issue.** A human reviews and merges the PR.
    - End with the line:
      `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
 
+6. VERIFY a PR now exists before claiming success:
+
+   `gh pr list --head {{BRANCH}} --state open --json number,url`
+
+   If this prints an empty list (`[]`), the push or PR creation did NOT land.
+   Do **not** output `<promise>COMPLETE</promise>` — print what went wrong and
+   stop.
+
 # RULES
 
 - Never run `git merge`, `gh pr merge`, or `gh issue close`.
 - Do not modify code here — implementation and review already happened on this
   branch. This step only publishes the branch and opens the PR.
+- Only output `<promise>COMPLETE</promise>` once you have CONFIRMED (step 3 +
+  step 6) that the branch is pushed AND an open PR exists. A failed push or a
+  missing PR is a failure, not a COMPLETE.
 
-Once the PR is open (or already existed), output `<promise>COMPLETE</promise>`.
+Once the branch is pushed and an open PR is confirmed to exist, output
+`<promise>COMPLETE</promise>`.

--- a/.sandcastle/plan-dry-run.ts
+++ b/.sandcastle/plan-dry-run.ts
@@ -37,7 +37,17 @@ const planSchema = z.object({
 // main.ts). We do NOT copyToWorktree node_modules (pnpm's symlinked store
 // breaks across the bind-mount).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container (FIRST hook).
+      // The planner is read-only and does not push, but every sandbox entrypoint
+      // installs `gh` as git's credential helper for consistency so no runner can
+      // regress to an unauthenticated `git push`. Guarded on GH_TOKEN so
+      // token-less local dev no-ops. See ./agent-implement-issue.ts for the note.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 const plan = await sandcastle.run({

--- a/.sandcastle/review-push-prompt.md
+++ b/.sandcastle/review-push-prompt.md
@@ -13,13 +13,31 @@ new PR.**
    If there is nothing ahead of `origin/{{BRANCH}}`, output
    `<promise>COMPLETE</promise>` and stop.
 
-2. Push:
+2. Wire `git push` authentication so the push below is NOT unauthenticated.
+   `gh` is authenticated from `GH_TOKEN`, but a bare `git push` uses git's own
+   credential system. Install `gh` as git's credential helper (idempotent; the
+   onSandboxReady hook already did this, but re-run it here so this step is
+   self-contained):
+
+   `gh auth setup-git`
+
+3. Push, then CONFIRM the remote tip advanced — a push can fail without an
+   obvious error:
 
    `git push origin {{BRANCH}}`
+   `git ls-remote --heads origin {{BRANCH}}`
+   !`git rev-parse {{BRANCH}}`
+
+   If the SHA printed by `git ls-remote` does NOT match your local
+   `git rev-parse {{BRANCH}}`, the push FAILED. Do **not** output
+   `<promise>COMPLETE</promise>` — print the push error and stop. The runner
+   verifies the branch advanced and will fail the job if it did not.
 
 # RULES
 
 - Never run `git merge`, `gh pr merge`, or `gh issue close`.
 - Do not open a new PR — the existing PR updates automatically from the push.
+- Only output `<promise>COMPLETE</promise>` once you have CONFIRMED the remote
+  tip matches your local branch tip. A failed push is a failure, not a COMPLETE.
 
-Once pushed, output `<promise>COMPLETE</promise>`.
+Once the push is confirmed to have landed, output `<promise>COMPLETE</promise>`.


### PR DESCRIPTION
Part of toon-protocol/toon-meta#178.

Propagates the git-push-auth + fail-loud fix proven in `store` (store#51, validated by store#52) into the rig sandcastle factory, and sweeps it across **all** runner entrypoints (gotcha-#7 sweep).

## Why
sandcastle 0.12.0 does NO git-credential setup in its sandbox — it configures git identity + `safe.directory` but installs no credential helper. `gh` is authenticated from `GH_TOKEN`, but a bare in-sandbox `git push` over HTTPS uses git's own credential system, which is unwired to the token. Pushes therefore succeed only by luck and otherwise fail silently while the runner logs false success (store#50).

## Part A — deterministic auth
Guarded `gh auth setup-git` (`if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi`) added as the **first** `onSandboxReady` hook in every entrypoint that creates a sandbox — `agent-implement-issue.ts`, `agent-review-pr.ts`, `main.ts`, `plan-dry-run.ts` — prepended before the existing `pnpm install --frozen-lockfile` (install preserved, not replaced). The helper installs `gh` as git's credential helper and stores **no token in any file** (it reads `GH_TOKEN` at push time). Guarded on `GH_TOKEN` so token-less local dev no-ops instead of aborting sandbox setup.

## Part B — fail loud
- `agent-implement-issue.ts`: after the open-pr phase, verify from the authenticated host `gh` that an OPEN PR actually exists for the branch; if not, dump the push/PR state and `process.exit(1)` (replacing the unconditional success log) so the Actions job goes red instead of green-lying.
- `agent-review-pr.ts`: analogous — capture origin's PR-branch tip before the review push and confirm it advanced after; if not, exit non-zero.

## Prompt hardening
`open-pr-prompt.md` and `review-push-prompt.md` now run `gh auth setup-git` before pushing and verify the remote ref with `git ls-remote` after, only emitting `<promise>COMPLETE</promise>` once push (and PR, for open-pr) are confirmed.

## Scope / safety
- Touches only `.sandcastle/*`. No changes to loops/ci/release/publish.
- No token literal in any committed file or log.
- TypeScript clean (all four edited `.ts` files typecheck with node types).
- Changeset gate not triggered: rig's check fires only on `packages/rig/` changes; `.sandcastle/*` is root-level, so no changeset is required.

Do NOT merge via automation — awaiting human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)