### PR TITLE
factory: tier sandcastle worker models + 60% context handoff

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -133,7 +133,7 @@ try {
   const implement = await sandbox.run({
     name: "implementer",
     maxIterations: 100,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/implement-prompt.md",
     promptArgs: {
       TASK_ID: issueNumber,
@@ -157,7 +157,7 @@ try {
   await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: branch },
   });
@@ -184,7 +184,7 @@ try {
     await sandbox.run({
       name: "open-pr",
       maxIterations: 1,
-      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      agent: sandcastle.claudeCode("claude-sonnet-5"),
       promptFile: "./.sandcastle/open-pr-prompt.md",
       promptArgs: {
         TASK_ID: issueNumber,

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -113,7 +113,7 @@ try {
   const review = await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: headRef },
   });
@@ -136,7 +136,7 @@ try {
     await sandbox.run({
       name: "push-review",
       maxIterations: 1,
-      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      agent: sandcastle.claudeCode("claude-sonnet-5"),
       promptFile: "./.sandcastle/review-push-prompt.md",
       promptArgs: { BRANCH: headRef },
     });

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -67,3 +67,7 @@ Once complete, output <promise>COMPLETE</promise>.
 # FINAL RULES
 
 ONLY WORK ON A SINGLE TASK.
+
+## Context budget
+
+If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -148,7 +148,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
         const implement = await sandbox.run({
           name: "implementer",
           maxIterations: 100,
-          agent: sandcastle.claudeCode("claude-opus-4-8"),
+          agent: sandcastle.claudeCode("claude-sonnet-5"),
           promptFile: "./.sandcastle/implement-prompt.md",
           promptArgs: {
             TASK_ID: issue.id,
@@ -162,7 +162,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
           const review = await sandbox.run({
             name: "reviewer",
             maxIterations: 1,
-            agent: sandcastle.claudeCode("claude-opus-4-8"),
+            agent: sandcastle.claudeCode("claude-sonnet-5"),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
               BRANCH: issue.branch,

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -53,3 +53,7 @@ If you find improvements to make:
 If the code is already clean and well-structured, do nothing.
 
 Once complete, output <promise>COMPLETE</promise>.
+
+## Context budget
+
+If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.


### PR DESCRIPTION
## Summary
- Model tiering: `implementer`, `reviewer`, `open-pr`, and `push-review` (review-push) roles now run on `claude-sonnet-5` in all four `.sandcastle/*.ts` runners (`main.ts`, `agent-implement-issue.ts`, `agent-review-pr.ts`). `planner` / `planner-dry-run` / `merger` stay on `claude-opus-4-8`.
- Context budget: appended a `## Context budget` section to `implement-prompt.md` and `review-prompt.md` instructing the agent to write a handoff note to `.sandcastle/logs/handoff-<task-id>.md` and end its turn if it approaches ~60% of its context window, rather than degrading through one long run.

## Scope
Touches only `.sandcastle/*` (root-level) — does not touch `packages/rig/`, so the CI changeset gate does not fire (verified against `.github/workflows/ci.yml`); no changeset added.

Part of toon-protocol/toon-meta#202
#178

## Test plan
- [ ] `pnpm -r build` / `pnpm -r test` unaffected (no package code changed)
- [ ] Spot-check a `.sandcastle` run picks up `claude-sonnet-5` for implementer/reviewer/open-pr/review-push and `claude-opus-4-8` for planner/merger

🤖 Generated with [Claude Code](https://claude.com/claude-code)