### PR TITLE
feat(rig)!: move onto @toon-protocol/client 0.22.0 (sealed wire + flat route price)

### DIFF
--- a/.changeset/client-0-22-sealed-wire-flat-price.md
+++ b/.changeset/client-0-22-sealed-wire-flat-price.md
@@ -1,9 +1,30 @@
 ---
-'@toon-protocol/rig': major
+'@toon-protocol/rig': minor
 ---
 
 Move onto `@toon-protocol/client` 0.22.0: the sealed wire, and a flat price
-asked of the route. **Breaking.**
+asked of the route — plus the `DEFAULT_RIG_WEB_URL` pointer fix, which is the
+only part of this release a consumer on `3.0.0` has not already got.
+
+**Read the bump first.** This is the first release published from the
+`toon-protocol/rig` repository; `1.0.0`–`3.0.0` were published from the
+`toon-client` monorepo, where this package used to live. npm's `3.0.0` was cut
+from the tree that already contains everything described below except the
+pointer URL — so relative to `3.0.0` this release **breaks nothing**, and is a
+`minor`. The removals below are recorded for anyone arriving from `2.x`; if you
+are on `3.0.0` you have already done that migration.
+
+**What actually changes for a `3.0.0` consumer.** `DEFAULT_RIG_WEB_URL` — the
+rig pointer's no-JS/delayed fallback link, embedded permanently into every
+Arweave-published rig pointer — now points at
+`https://toon-protocol.github.io/rig` instead of the retired
+`toon-protocol.github.io/toon-client` copy. `rig` now solely owns `rig-web`;
+`/toon-client/` is a permanent fragment-preserving redirect stub.
+
+---
+
+The rest of this entry describes the `2.x` → `3.x` move, already shipped in
+`3.0.0`.
 
 Both pins (`packages/rig`, `packages/rig-web`) go `^0.21.1` → `^0.22.0`. The
 client's 0.22.0 is itself breaking on two axes, and this package's public
@@ -31,7 +52,7 @@ more handlers. A 100-byte and a 100 KB upload to the same store route now cost
 the same, and the connector gates every paid packet at that figure regardless
 of what a client computes.
 
-So the following are **removed**, not deprecated:
+So the following are **removed**, not deprecated (as of `3.0.0`):
 
 - `FeeRates.uploadFeePerByte` and `FeeRates.minUploadFee`, replaced by one flat
   `FeeRates.uploadFee`.
@@ -47,5 +68,3 @@ is a lie told to every caller who sets it, and it would silently misprice
 a per-byte computation, so `getFeeRates()` — and with it the `rig push` confirm
 table, the rig-page pointer fee and `rig site` estimates — equals what is
 claimed.
-
-`@toon-protocol/rig` is past 1.0, so removing exported API is a major bump.

--- a/.changeset/client-0-22-sealed-wire-flat-price.md
+++ b/.changeset/client-0-22-sealed-wire-flat-price.md
@@ -1,0 +1,51 @@
+---
+'@toon-protocol/rig': major
+---
+
+Move onto `@toon-protocol/client` 0.22.0: the sealed wire, and a flat price
+asked of the route. **Breaking.**
+
+Both pins (`packages/rig`, `packages/rig-web`) go `^0.21.1` → `^0.22.0`. The
+client's 0.22.0 is itself breaking on two axes, and this package's public
+surface moves with it rather than papering over it. The changes below mirror
+the ones already made to the copy of rig that lives in the toon-client monorepo
+(toon-client#457 and #459) — the two copies stay one implementation.
+
+**The store's answer is a sealed envelope, not HTTP text.**
+`parseFulfillHttp` is gone from the client: a paid write is now an OER
+`EnvelopeRequest` (ADR 0018) inside a gift wrap, and the answer comes back
+sealed under the same secret. `PublishEventResult.data` (base64 HTTP/1.1 text)
+becomes `PublishEventResult.response` (the opened response envelope).
+
+`extractArweaveTxId` is therefore no longer reimplemented here — it is
+re-exported from `@toon-protocol/client`. Its parameter type changes from
+`string` to the response envelope, and the legacy bare-base64-txId branch is
+gone with the wire that carried it. This file only ever carried a copy because
+the client's extractor was thought not to be exported; it is, and with one
+answer shape left to read a second reader could only drift from it.
+
+**A price is flat per route, and the route is asked for it.**
+ADR 0020 (toon-client#452) removes byte-proportional pricing from the protocol:
+one handler, one price, and an app that wants to charge differently exposes
+more handlers. A 100-byte and a 100 KB upload to the same store route now cost
+the same, and the connector gates every paid packet at that figure regardless
+of what a client computes.
+
+So the following are **removed**, not deprecated:
+
+- `FeeRates.uploadFeePerByte` and `FeeRates.minUploadFee`, replaced by one flat
+  `FeeRates.uploadFee`.
+- `flooredUploadFee()`, the `max(bytes × rate, floor)` helper the two fields
+  existed to feed.
+- `StandalonePublisherOptions.uploadFeePerByte`.
+
+`uploadFeePerByte` was a public constructor option, and keeping it accepted-but-
+ignored was rejected: a per-byte fee that cannot change what any packet costs
+is a lie told to every caller who sets it, and it would silently misprice
+`planPush` estimates against the claims actually signed. The already-present
+`routePrices.store` now carries the whole upload fee rather than a floor under
+a per-byte computation, so `getFeeRates()` — and with it the `rig push` confirm
+table, the rig-page pointer fee and `rig site` estimates — equals what is
+claimed.
+
+`@toon-protocol/rig` is past 1.0, so removing exported API is a major bump.

--- a/packages/rig-web/package.json
+++ b/packages/rig-web/package.json
@@ -37,7 +37,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
-    "@toon-protocol/client": "^0.21.1",
+    "@toon-protocol/client": "^0.22.0",
     "@toon-protocol/core": "^1.6.0",
     "@toon-protocol/relay": "^1.3.1",
     "@toon-protocol/rig": "workspace:*",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.21.1",
+    "@toon-protocol/client": "^0.22.0",
     "@toon-protocol/core": "^3.1.2",
     "nostr-tools": "^2.20.0"
   },

--- a/packages/rig/src/cli/balance.test.ts
+++ b/packages/rig/src/cli/balance.test.ts
@@ -70,7 +70,7 @@ function makeHarness(
     identitySource: 'env',
     identitySourceLabel: 'RIG_MNEMONIC env',
     publisher: {
-      getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 1n }),
+      getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1n }),
       uploadGitObject: async () => {
         throw new Error('balance never uploads');
       },
@@ -187,7 +187,9 @@ describe('rig balance', () => {
       chainKey: 'solana',
       address: SOL_ADDR,
       native: { symbol: 'SOL', amount: '2000000000', decimals: 9 },
-      tokens: [{ symbol: 'USDC', amount: '0', decimals: 6, address: 'MintUSDC' }],
+      tokens: [
+        { symbol: 'USDC', amount: '0', decimals: 6, address: 'MintUSDC' },
+      ],
     },
     {
       chain: 'mina',
@@ -291,7 +293,9 @@ describe('rig balance', () => {
   it('--json carries the full per-chain native+tokens shape', async () => {
     const h = makeHarness({ TOON_CLIENT_HOME: dir }, WALLET);
     expect(await runBalance(['--json'], h.deps)).toBe(0);
-    const parsed = JSON.parse(h.out.join('\n')) as { wallet: WalletChainBalanceInfo[] };
+    const parsed = JSON.parse(h.out.join('\n')) as {
+      wallet: WalletChainBalanceInfo[];
+    };
     expect(parsed.wallet).toEqual(WALLET);
     expect(parsed.wallet[0]).toMatchObject({
       chain: 'evm',
@@ -327,7 +331,10 @@ describe('rig balance', () => {
     const h = makeHarness({ TOON_CLIENT_HOME: dir });
     expect(await runBalance(['--json'], h.deps)).toBe(0);
     const parsed = JSON.parse(h.out.join('\n')) as {
-      channels: { available: string | null; cumulativeClaimed: string | null }[];
+      channels: {
+        available: string | null;
+        cumulativeClaimed: string | null;
+      }[];
     };
     expect(parsed.channels[0]).toMatchObject({
       available: null,
@@ -520,9 +527,9 @@ describe('rig balance', () => {
     });
 
     it('resolves with the value when the read finishes in time', async () => {
-      await expect(readWalletBounded(async () => WALLET, 1000)).resolves.toEqual(
-        WALLET
-      );
+      await expect(
+        readWalletBounded(async () => WALLET, 1000)
+      ).resolves.toEqual(WALLET);
     });
 
     it('a non-positive timeout opts out of the bound (waits for the read)', async () => {
@@ -532,13 +539,15 @@ describe('rig balance', () => {
     });
 
     it('parses the env override; falls back to the default on junk/absent', () => {
-      expect(walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: '500' })).toBe(
-        500
+      expect(
+        walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: '500' })
+      ).toBe(500);
+      expect(walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: '0' })).toBe(
+        0
       );
-      expect(walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: '0' })).toBe(0);
-      expect(walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: 'nope' })).toBe(
-        20_000
-      );
+      expect(
+        walletReadTimeoutMs({ RIG_BALANCE_WALLET_TIMEOUT_MS: 'nope' })
+      ).toBe(20_000);
       expect(walletReadTimeoutMs({})).toBe(20_000);
     });
   });

--- a/packages/rig/src/cli/channel.test.ts
+++ b/packages/rig/src/cli/channel.test.ts
@@ -126,7 +126,7 @@ function makeMoney(identity: string = IDENTITY): FakeMoney {
     identitySource: 'env',
     identitySourceLabel: 'RIG_MNEMONIC env',
     publisher: {
-      getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 1n }),
+      getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1n }),
       uploadGitObject: async () => {
         throw new Error('channel commands never upload');
       },
@@ -323,7 +323,10 @@ describe('rig channel', () => {
         { loadStandalone: fake.load }
       );
       expect(
-        await runChannel(['open', '--peer', 'g.other.relay.store', '--yes'], h.deps)
+        await runChannel(
+          ['open', '--peer', 'g.other.relay.store', '--yes'],
+          h.deps
+        )
       ).toBe(0);
       expect(fake.loads[0]?.channelDestination).toBe('g.other.relay.store');
     });
@@ -369,7 +372,9 @@ describe('rig channel', () => {
           { TOON_CLIENT_HOME: dir },
           { loadStandalone: fake.load }
         );
-        expect(await runChannel(['open', '--deposit', bad, '--yes'], h.deps)).toBe(2);
+        expect(
+          await runChannel(['open', '--deposit', bad, '--yes'], h.deps)
+        ).toBe(2);
         expect(fake.openCalls).toEqual([]);
       }
     });
@@ -598,7 +603,9 @@ describe('rig channel', () => {
         { TOON_CLIENT_HOME: dir },
         { loadStandalone: fake.load }
       );
-      expect(await runChannel(['close', CHANNEL_ID, '--json'], plan.deps)).toBe(0);
+      expect(await runChannel(['close', CHANNEL_ID, '--json'], plan.deps)).toBe(
+        0
+      );
       const parsed = JSON.parse(plan.out.join('\n')) as Record<string, unknown>;
       expect(parsed).toMatchObject({
         command: 'channel close',

--- a/packages/rig/src/cli/events.test.ts
+++ b/packages/rig/src/cli/events.test.ts
@@ -27,10 +27,7 @@ import {
 } from './events.js';
 import { writeToonConfig } from './git-config.js';
 import type { CliIo } from './push.js';
-import {
-  filterEvents,
-  makeMockRelayFactory,
-} from './read-testkit.js';
+import { filterEvents, makeMockRelayFactory } from './read-testkit.js';
 import type { StandaloneContext } from './standalone-context.js';
 import type { NostrEvent } from '../remote-state.js';
 
@@ -159,7 +156,7 @@ interface FakeStandalone {
 function makeStandalone(): FakeStandalone {
   const published: FakeStandalone['published'] = [];
   const publisher: Publisher = {
-    getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 3n }),
+    getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 3n }),
     uploadGitObject: async () => {
       throw new Error('single-event commands never upload objects');
     },
@@ -219,12 +216,24 @@ describe('rig issue create', () => {
   it('publishes the issue event with the config-resolved repo address', async () => {
     const h = deps();
     const code = await runIssue(
-      ['create', '--title', 'Fix the flux', '--body', 'It broke.', '--label', 'bug', '--label', 'ui', '--yes'],
+      [
+        'create',
+        '--title',
+        'Fix the flux',
+        '--body',
+        'It broke.',
+        '--label',
+        'bug',
+        '--label',
+        'ui',
+        '--yes',
+      ],
       h.deps
     );
     expect(code).toBe(0);
     expect(fake.published).toHaveLength(1);
-    const { event, relayUrls } = fake.published[0] as FakeStandalone['published'][0];
+    const { event, relayUrls } = fake
+      .published[0] as FakeStandalone['published'][0];
     expect(event.kind).toBe(1621);
     expect(event.content).toBe('It broke.');
     expect(event.tags).toContainEqual(['a', `30617:${CONFIG_OWNER}:demo`]);
@@ -239,7 +248,9 @@ describe('rig issue create', () => {
     expect(text).toContain('30617:' + CONFIG_OWNER + ':demo');
     expect(text).toContain(`Identity: ${OWNER} (from /repo/.env)`);
     expect(text).toContain('permanent and non-refundable');
-    expect(text).toContain(`Published kind:1621 issue "Fix the flux": ${EVENT_ID}`);
+    expect(text).toContain(
+      `Published kind:1621 issue "Fix the flux": ${EVENT_ID}`
+    );
     expect(text).toContain('paid 3 base units');
   });
 
@@ -282,7 +293,18 @@ describe('rig issue create', () => {
   it('--repo-id and --owner override the git config address', async () => {
     const h = deps();
     const code = await runIssue(
-      ['create', '--title', 't', '--body', 'b', '--yes', '--repo-id', 'other', '--owner', OWNER],
+      [
+        'create',
+        '--title',
+        't',
+        '--body',
+        'b',
+        '--yes',
+        '--repo-id',
+        'other',
+        '--owner',
+        OWNER,
+      ],
       h.deps
     );
     expect(code).toBe(0);
@@ -295,7 +317,16 @@ describe('rig issue create', () => {
   it('rejects a non-hex --owner before doing anything (exit 2)', async () => {
     const h = deps();
     const code = await runIssue(
-      ['create', '--title', 't', '--body', 'b', '--yes', '--owner', 'npub1notahexkey'],
+      [
+        'create',
+        '--title',
+        't',
+        '--body',
+        'b',
+        '--yes',
+        '--owner',
+        'npub1notahexkey',
+      ],
       h.deps
     );
     expect(code).toBe(2);
@@ -338,7 +369,10 @@ describe('rig issue create', () => {
 
       const j = makeDeps(env, bare, { loadStandalone: fake.load });
       expect(
-        await runIssue(['create', '--title', 't', '--body', 'b', '--yes', '--json'], j.deps)
+        await runIssue(
+          ['create', '--title', 't', '--body', 'b', '--yes', '--json'],
+          j.deps
+        )
       ).toBe(1);
       expect(JSON.parse(j.out.join('\n'))).toMatchObject({
         command: 'issue',
@@ -410,7 +444,10 @@ describe('confirm gating', () => {
 describe('rig comment', () => {
   it('publishes kind:1622 with the default root marker and owner p-tag', async () => {
     const h = deps();
-    const code = await runComment([ROOT_EVENT, '--body', 'nice catch', '--yes'], h.deps);
+    const code = await runComment(
+      [ROOT_EVENT, '--body', 'nice catch', '--yes'],
+      h.deps
+    );
     expect(code).toBe(0);
     const { event } = fake.published[0] as FakeStandalone['published'][0];
     expect(event.kind).toBe(1622);
@@ -424,7 +461,16 @@ describe('rig comment', () => {
   it('passes --parent-author and --marker reply through', async () => {
     const h = deps();
     const code = await runComment(
-      [ROOT_EVENT, '--body', 'b', '--parent-author', OWNER, '--marker', 'reply', '--yes'],
+      [
+        ROOT_EVENT,
+        '--body',
+        'b',
+        '--parent-author',
+        OWNER,
+        '--marker',
+        'reply',
+        '--yes',
+      ],
       h.deps
     );
     expect(code).toBe(0);
@@ -436,7 +482,10 @@ describe('rig comment', () => {
   it('validates the root event id, marker, and body (exit 2)', async () => {
     expect(await runComment(['not-hex', '--body', 'b'], deps().deps)).toBe(2);
     expect(
-      await runComment([ROOT_EVENT, '--body', 'b', '--marker', 'sideways'], deps().deps)
+      await runComment(
+        [ROOT_EVENT, '--body', 'b', '--marker', 'sideways'],
+        deps().deps
+      )
     ).toBe(2);
     expect(await runComment([ROOT_EVENT], deps().deps)).toBe(2);
     expect(await runComment([], deps().deps)).toBe(2);
@@ -449,7 +498,16 @@ describe('rig pr create (real format-patch)', () => {
     const [first, second] = addSecondCommit(repoDir);
     const h = deps();
     const code = await runPr(
-      ['create', '--title', 'Add feature', '--range', `${first}..${second}`, '--branch', 'feature', '--yes'],
+      [
+        'create',
+        '--title',
+        'Add feature',
+        '--range',
+        `${first}..${second}`,
+        '--branch',
+        'feature',
+        '--yes',
+      ],
       h.deps
     );
     expect(code).toBe(0);
@@ -578,11 +636,23 @@ describe('rig pr create (real format-patch)', () => {
     const h = deps();
     expect(
       await runPr(
-        ['create', '--title', 't', '--range', 'a..b', '--body', 'x', '--body-file', 'y'],
+        [
+          'create',
+          '--title',
+          't',
+          '--range',
+          'a..b',
+          '--body',
+          'x',
+          '--body-file',
+          'y',
+        ],
         h.deps
       )
     ).toBe(2);
-    expect(h.err.join('\n')).toContain('--body and --body-file are mutually exclusive');
+    expect(h.err.join('\n')).toContain(
+      '--body and --body-file are mutually exclusive'
+    );
     expect(fake.published).toHaveLength(0);
   });
 
@@ -601,7 +671,9 @@ describe('rig pr create (real format-patch)', () => {
   it('requires exactly one of --range | --patch-file (exit 2)', async () => {
     const h = deps();
     expect(await runPr(['create', '--title', 't'], h.deps)).toBe(2);
-    expect(h.err.join('\n')).toContain('exactly one of --range or --patch-file');
+    expect(h.err.join('\n')).toContain(
+      'exactly one of --range or --patch-file'
+    );
     expect(
       await runPr(
         ['create', '--title', 't', '--range', 'a..b', '--patch-file', 'x'],
@@ -626,7 +698,10 @@ describe('rig pr create (real format-patch)', () => {
 describe('rig pr status', () => {
   it('publishes the mapped status kind with the repo a-tag', async () => {
     const h = deps();
-    const code = await runPr(['status', ROOT_EVENT, 'applied', '--yes'], h.deps);
+    const code = await runPr(
+      ['status', ROOT_EVENT, 'applied', '--yes'],
+      h.deps
+    );
     expect(code).toBe(0);
     const { event } = fake.published[0] as FakeStandalone['published'][0];
     expect(event.kind).toBe(1631);
@@ -718,7 +793,10 @@ describe('relay selection (#249)', () => {
       relays: ['wss://one.example', 'wss://two.example'],
     });
     const h = deps();
-    const code = await runIssue(['create', '--title', 't', '--body', 'b', '--yes'], h.deps);
+    const code = await runIssue(
+      ['create', '--title', 't', '--body', 'b', '--yes'],
+      h.deps
+    );
     expect(code).toBe(1);
     const text = h.err.join('\n');
     expect(text).toContain('single relay');
@@ -732,7 +810,16 @@ describe('relay selection (#249)', () => {
   it('an explicit single --relay overrides the configured remotes', async () => {
     const h = deps();
     const code = await runIssue(
-      ['create', '--title', 't', '--body', 'b', '--yes', '--relay', 'wss://chosen.example'],
+      [
+        'create',
+        '--title',
+        't',
+        '--body',
+        'b',
+        '--yes',
+        '--relay',
+        'wss://chosen.example',
+      ],
       h.deps
     );
     expect(code).toBe(0);
@@ -832,7 +919,10 @@ describe('error mapping', () => {
         throw new Error('publish exploded');
       },
     });
-    const code = await runPr(['status', ROOT_EVENT, 'open', '--json', '--yes'], h.deps);
+    const code = await runPr(
+      ['status', ROOT_EVENT, 'open', '--json', '--yes'],
+      h.deps
+    );
     expect(code).toBe(1);
     expect(JSON.parse(h.out.join('\n'))).toMatchObject({
       command: 'pr status',
@@ -866,12 +956,17 @@ describe('usage', () => {
 
   it('rejects unknown flags (incl. the removed --daemon mode flag) with usage (exit 2)', async () => {
     const h = deps();
-    expect(await runPr(['status', ROOT_EVENT, 'open', '--frobnicate'], h.deps)).toBe(2);
+    expect(
+      await runPr(['status', ROOT_EVENT, 'open', '--frobnicate'], h.deps)
+    ).toBe(2);
     expect(h.err.join('\n')).toContain('Usage: rig pr status');
     // --daemon was removed and stays unknown; --standalone/--no-daemon are now
     // valid force-standalone flags (covered in the delegation describe below).
     expect(
-      await runIssue(['create', '--title', 't', '--body', 'b', '--daemon'], deps().deps)
+      await runIssue(
+        ['create', '--title', 't', '--body', 'b', '--daemon'],
+        deps().deps
+      )
     ).toBe(2);
     expect(fake.published).toHaveLength(0);
   });
@@ -888,14 +983,15 @@ describe('daemon delegation (#279)', () => {
   let SELF: string;
 
   beforeEach(async () => {
-    const { deriveNostrKeyFromMnemonic } = await import(
-      '@toon-protocol/client'
-    );
+    const { deriveNostrKeyFromMnemonic } =
+      await import('@toon-protocol/client');
     SELF = deriveNostrKeyFromMnemonic(TEST_MNEMONIC, 0).pubkey;
   });
 
   const sameIdentityProbe =
-    (relayUrl = 'wss://origin-relay.example'): NonNullable<EventCommandDeps['probeDaemon']> =>
+    (
+      relayUrl = 'wss://origin-relay.example'
+    ): NonNullable<EventCommandDeps['probeDaemon']> =>
     async () => ({
       baseUrl: 'http://127.0.0.1:8787',
       reachable: true,
@@ -997,10 +1093,7 @@ describe('daemon delegation (#279)', () => {
       probeDaemon: sameIdentityProbe('wss://daemon-relay.example'),
       fetchImpl,
     });
-    const code = await runComment(
-      [ROOT_EVENT, '--body', 'B', '--yes'],
-      h.deps
-    );
+    const code = await runComment([ROOT_EVENT, '--body', 'B', '--yes'], h.deps);
     expect(code).toBe(0);
     expect(h.err.join('\n')).toContain(
       'daemon publishes via its configured relay'
@@ -1060,10 +1153,7 @@ describe('daemon delegation (#279)', () => {
         return new Response('Not Found', { status: 404 });
       }) as typeof fetch,
     });
-    const code = await runComment(
-      [ROOT_EVENT, '--body', 'B', '--yes'],
-      h.deps
-    );
+    const code = await runComment([ROOT_EVENT, '--body', 'B', '--yes'], h.deps);
     expect(code).toBe(1);
     const text = h.err.join('\n');
     expect(text).toContain('too old to handle git operations');
@@ -1089,7 +1179,8 @@ describe('daemon delegation (#279)', () => {
   });
 
   it('pr create --patch-file delegates the EXACT local patch text', async () => {
-    const patch = 'From 0123456789012345678901234567890123456789 Mon Sep 17\n---\npatch body\n';
+    const patch =
+      'From 0123456789012345678901234567890123456789 Mon Sep 17\n---\npatch body\n';
     const patchPath = join(repoDir, 'x.patch');
     writeFileSync(patchPath, patch);
     const receipt = { eventId: EVENT_ID, feePaid: '7', kind: 1617 };
@@ -1109,7 +1200,8 @@ describe('daemon delegation (#279)', () => {
   });
 
   it('pr create --body delegates the description to /git/patch', async () => {
-    const patch = 'From 0123456789012345678901234567890123456789 Mon Sep 17\n---\npatch body\n';
+    const patch =
+      'From 0123456789012345678901234567890123456789 Mon Sep 17\n---\npatch body\n';
     const patchPath = join(repoDir, 'x.patch');
     writeFileSync(patchPath, patch);
     const receipt = { eventId: EVENT_ID, feePaid: '7', kind: 1617 };
@@ -1119,7 +1211,16 @@ describe('daemon delegation (#279)', () => {
       fetchImpl,
     });
     const code = await runPr(
-      ['create', '--title', 'P', '--patch-file', patchPath, '--body', 'the why', '--yes'],
+      [
+        'create',
+        '--title',
+        'P',
+        '--patch-file',
+        patchPath,
+        '--body',
+        'the why',
+        '--yes',
+      ],
       h.deps
     );
     expect(code).toBe(0);

--- a/packages/rig/src/cli/maintainers.test.ts
+++ b/packages/rig/src/cli/maintainers.test.ts
@@ -52,7 +52,7 @@ interface Fake {
 function makeStandalone(identity = OWNER): Fake {
   const published: Fake['published'] = [];
   const publisher: Publisher = {
-    getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 5n }),
+    getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 5n }),
     uploadGitObject: async () => {
       throw new Error('maintainers never uploads objects');
     },
@@ -256,9 +256,9 @@ describe('rig maintainers add/remove (paid, owner-only)', () => {
     expect(
       await runMaintainers(['add', 'nothex', ...ADDR], makeDeps(io, fake, []))
     ).toBe(2);
-    expect(
-      await runMaintainers(['bogus'], makeDeps(makeIo(), fake, []))
-    ).toBe(2);
+    expect(await runMaintainers(['bogus'], makeDeps(makeIo(), fake, []))).toBe(
+      2
+    );
     expect(fake.published).toHaveLength(0);
   });
 });

--- a/packages/rig/src/cli/push.test.ts
+++ b/packages/rig/src/cli/push.test.ts
@@ -19,7 +19,10 @@ import { join } from 'node:path';
 import type { Publisher } from '../publisher.js';
 import type { RemoteState } from '../remote-state.js';
 import { readToonConfig, writeToonConfig } from './git-config.js';
-import { readRigPointerRecord, writeRigPointerRecord } from './rig-pointer-record.js';
+import {
+  readRigPointerRecord,
+  writeRigPointerRecord,
+} from './rig-pointer-record.js';
 import { runPush, selectRefspecs, type CliIo, type PushDeps } from './push.js';
 import { GitRepoReader } from '../repo-reader.js';
 import type {
@@ -140,7 +143,11 @@ interface FakeStandalone {
   uploads: { sha: string; size: number }[];
   blobs: { contentType: string; size: number; body: string }[];
   published: { kind: number; relayUrls: string[] }[];
-  remoteRequests: { ownerPubkey: string; repoId: string; relayUrls: string[] }[];
+  remoteRequests: {
+    ownerPubkey: string;
+    repoId: string;
+    relayUrls: string[];
+  }[];
   loadedWith: StandaloneLoadOptions[];
   stopped: boolean;
   load: PushDeps['loadStandalone'];
@@ -164,7 +171,7 @@ function makeStandalone(
   const remoteRequests: FakeStandalone['remoteRequests'] = [];
   const loadedWith: FakeStandalone['loadedWith'] = [];
   const publisher: Publisher = {
-    getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 1n }),
+    getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1n }),
     uploadGitObject: async (upload) => {
       uploads.push({ sha: upload.sha, size: upload.body.length });
       return { txId: TX_ID, feePaid: BigInt(upload.body.length) * 10n };
@@ -175,10 +182,7 @@ function makeStandalone(
     },
     ...(options.withBlobUpload
       ? {
-          uploadBlob: async (upload: {
-            body: Buffer;
-            contentType: string;
-          }) => {
+          uploadBlob: async (upload: { body: Buffer; contentType: string }) => {
             if (options.blobUploadError) {
               throw new Error(options.blobUploadError);
             }
@@ -251,10 +255,9 @@ describe('selectRefspecs', () => {
     expect(await selectRefspecs(reader, [], false, false)).toEqual([
       'refs/heads/main',
     ]);
-    expect(await selectRefspecs(reader, ['feature', 'v1'], false, false)).toEqual([
-      'refs/heads/feature',
-      'refs/tags/v1',
-    ]);
+    expect(
+      await selectRefspecs(reader, ['feature', 'v1'], false, false)
+    ).toEqual(['refs/heads/feature', 'refs/tags/v1']);
     expect(await selectRefspecs(reader, [], true, true)).toEqual([
       'refs/heads/feature',
       'refs/heads/main',
@@ -482,8 +485,12 @@ describe('standalone push (Publisher seam)', () => {
     expect(fake2.published).toHaveLength(0);
     expect(fake2.blobs).toHaveLength(1);
     expect(h2.out.join('\n')).toContain('the Rig page is stale');
-    expect(h2.out.join('\n')).toContain(`Rig page: https://ar-io.dev/${POINTER_TX}`);
-    expect(readRigPointerRecord(env, 'demo')?.contentHash).not.toBe('f0'.repeat(32));
+    expect(h2.out.join('\n')).toContain(
+      `Rig page: https://ar-io.dev/${POINTER_TX}`
+    );
+    expect(readRigPointerRecord(env, 'demo')?.contentHash).not.toBe(
+      'f0'.repeat(32)
+    );
   });
 
   it('--no-rig-page skips the pointer entirely', async () => {
@@ -701,7 +708,9 @@ describe('remote resolution (#249)', () => {
     const code = await runPush(['upstream', 'main', '--yes'], h.deps);
     expect(code).toBe(1);
     const text = h.err.join('\n');
-    expect(text).toContain('neither a configured remote nor a local branch/tag');
+    expect(text).toContain(
+      'neither a configured remote nor a local branch/tag'
+    );
     expect(text).toContain('rig remote add upstream');
     expect(fake.loadedWith).toHaveLength(0);
     expect(fake.published).toHaveLength(0);
@@ -890,16 +899,15 @@ describe('daemon delegation (#279)', () => {
   let SELF: string;
 
   beforeEach(async () => {
-    const { deriveNostrKeyFromMnemonic } = await import(
-      '@toon-protocol/client'
-    );
+    const { deriveNostrKeyFromMnemonic } =
+      await import('@toon-protocol/client');
     SELF = deriveNostrKeyFromMnemonic(TEST_MNEMONIC, 0).pubkey;
     await writeToonConfig(repoDir, { repoId: 'demo' });
     git(['remote', 'add', 'origin', 'wss://origin-relay.example'], repoDir);
   });
 
-  const sameIdentityProbe = (): NonNullable<PushDeps['probeDaemon']> =>
-    async () => ({
+  const sameIdentityProbe =
+    (): NonNullable<PushDeps['probeDaemon']> => async () => ({
       baseUrl: 'http://127.0.0.1:8787',
       reachable: true,
       identity: SELF,
@@ -910,8 +918,8 @@ describe('daemon delegation (#279)', () => {
     });
 
   /** A same-identity daemon too old for the /git/* routes (no capabilities). */
-  const oldDaemonProbe = (): NonNullable<PushDeps['probeDaemon']> =>
-    async () => ({
+  const oldDaemonProbe =
+    (): NonNullable<PushDeps['probeDaemon']> => async () => ({
       baseUrl: 'http://127.0.0.1:8787',
       reachable: true,
       identity: SELF,
@@ -919,7 +927,9 @@ describe('daemon delegation (#279)', () => {
       // No `capabilities` field — an old client-mcp build (#306).
     });
 
-  function daemonPlan(overrides: Partial<GitEstimateResponse> = {}): GitEstimateResponse {
+  function daemonPlan(
+    overrides: Partial<GitEstimateResponse> = {}
+  ): GitEstimateResponse {
     return {
       repoId: 'demo',
       refUpdates: [
@@ -979,15 +989,11 @@ describe('daemon delegation (#279)', () => {
   it('delegates estimate + execute to the daemon; standalone loader untouched', async () => {
     const fake = makeStandalone(emptyRemoteState());
     const { posts, fetchImpl } = daemonFetch(daemonPlan());
-    const h = makeDeps(
-      { ...env, RIG_MNEMONIC: TEST_MNEMONIC },
-      repoDir,
-      {
-        loadStandalone: fake.load,
-        probeDaemon: sameIdentityProbe(),
-        fetchImpl,
-      }
-    );
+    const h = makeDeps({ ...env, RIG_MNEMONIC: TEST_MNEMONIC }, repoDir, {
+      loadStandalone: fake.load,
+      probeDaemon: sameIdentityProbe(),
+      fetchImpl,
+    });
     const code = await runPush(['--yes', '--json'], h.deps);
     expect(code).toBe(0);
 
@@ -1003,9 +1009,7 @@ describe('daemon delegation (#279)', () => {
     ]);
     expect(posts[0]?.body['repoId']).toBe('demo');
     expect(posts[0]?.body['refspecs']).toEqual(['refs/heads/main']);
-    expect(posts[0]?.body['relayUrls']).toEqual([
-      'wss://origin-relay.example',
-    ]);
+    expect(posts[0]?.body['relayUrls']).toEqual(['wss://origin-relay.example']);
     expect(posts[1]?.body['confirm']).toBe(true);
 
     const doc = JSON.parse(h.out.join('\n')) as Record<string, unknown>;

--- a/packages/rig/src/cli/push.ts
+++ b/packages/rig/src/cli/push.ts
@@ -49,10 +49,12 @@ import {
 } from '../rig-pointer.js';
 import { ARWEAVE_GATEWAYS } from '@toon-protocol/arweave';
 import { hexToNpub } from '../npub.js';
-import { flooredUploadFee } from '../publisher.js';
 import { planPush, executePush } from '../push.js';
 import { GitRepoReader } from '../repo-reader.js';
-import { readRigPointerRecord, writeRigPointerRecord } from './rig-pointer-record.js';
+import {
+  readRigPointerRecord,
+  writeRigPointerRecord,
+} from './rig-pointer-record.js';
 import { renderIdentityLine, renderPlan, renderResult } from './render.js';
 import {
   serializePushPlan,
@@ -68,10 +70,17 @@ import {
 } from './daemon-session.js';
 import { RIG_STANDALONE_ENV } from '../standalone/nonce-guard.js';
 import { emitCliError, UnconfiguredRepoAddressError } from './errors.js';
-import { listGitRemotes, readToonConfig, resolveRepoRoot } from './git-config.js';
+import {
+  listGitRemotes,
+  readToonConfig,
+  resolveRepoRoot,
+} from './git-config.js';
 import type { IdentitySourceKind } from './identity.js';
 import { resolveRelays, singleRelayRefusal } from './remote.js';
-import type { LoadStandalone, StandaloneContext } from './standalone-context.js';
+import type {
+  LoadStandalone,
+  StandaloneContext,
+} from './standalone-context.js';
 
 // ---------------------------------------------------------------------------
 // Dependency seam (real wiring in rig.ts; tests inject fakes)
@@ -420,9 +429,8 @@ function planRigPointer(args: {
   ownerPubkey: string;
   repoId: string;
   relay: string;
-  uploadFeePerByte: bigint;
-  /** Per-upload route-price floor (see FeeRates.minUploadFee). */
-  minUploadFee?: bigint;
+  /** Flat cost of one upload — the store route's price (see FeeRates.uploadFee). */
+  uploadFee: bigint;
 }): RigPointerPlan {
   const html = generateRigPointerHtml({
     bundle: {
@@ -431,9 +439,10 @@ function planRigPointer(args: {
       entryCss:
         args.env[RIG_WEB_ENTRY_CSS_ENV] ?? DEFAULT_RIG_WEB_BUNDLE.entryCss,
     },
-    gateway: (
-      args.env[RIG_WEB_GATEWAY_ENV] ?? DEFAULT_RIG_WEB_GATEWAY
-    ).replace(/\/+$/, ''),
+    gateway: (args.env[RIG_WEB_GATEWAY_ENV] ?? DEFAULT_RIG_WEB_GATEWAY).replace(
+      /\/+$/,
+      ''
+    ),
     rigWebUrl: args.env[RIG_WEB_URL_ENV] ?? DEFAULT_RIG_WEB_URL,
     relay: args.relay,
     ownerNpub: hexToNpub(args.ownerPubkey),
@@ -461,7 +470,7 @@ function planRigPointer(args: {
     html,
     contentHash,
     bytes,
-    fee: flooredUploadFee(bytes, args.uploadFeePerByte, args.minUploadFee),
+    fee: args.uploadFee,
   };
 }
 
@@ -643,10 +652,7 @@ export async function runPush(args: string[], deps: PushDeps): Promise<number> {
           ownerPubkey: ctx.ownerPubkey,
           repoId,
           relay: relaysUsed[0],
-          uploadFeePerByte: feeRates.uploadFeePerByte,
-          ...(feeRates.minUploadFee !== undefined
-            ? { minUploadFee: feeRates.minUploadFee }
-            : {}),
+          uploadFee: feeRates.uploadFee,
         });
       }
     } else {
@@ -669,7 +675,8 @@ export async function runPush(args: string[], deps: PushDeps): Promise<number> {
         });
       // The delegated daemon owns the paid pipeline but exposes no raw-blob
       // upload route yet — the pointer refreshes on the next standalone push.
-      rigPageSkipDetail = 'skipped on the daemon path (refreshes on the next standalone push)';
+      rigPageSkipDetail =
+        'skipped on the daemon path (refreshes on the next standalone push)';
     }
 
     // ── Rig-page pointer publish (shared by the normal path and the
@@ -717,7 +724,9 @@ export async function runPush(args: string[], deps: PushDeps): Promise<number> {
       if (rigPage.url) {
         io.out(
           `Rig page: ${rigPage.url}` +
-            (rigPage.status === 'published' ? `  paid ${rigPage.feePaid}` : '') +
+            (rigPage.status === 'published'
+              ? `  paid ${rigPage.feePaid}`
+              : '') +
             '  (renders this repo from Arweave)'
         );
         const mirror = rigPage.txId ? mirrorGateway(gateway) : undefined;
@@ -861,7 +870,10 @@ export async function runPush(args: string[], deps: PushDeps): Promise<number> {
     // ── Rig-page pointer (after the push succeeded; never fails it) ─────────
     let rigPage: RigPageReport;
     if (!pointerPlan) {
-      rigPage = { status: 'skipped', ...(rigPageSkipDetail ? { detail: rigPageSkipDetail } : {}) };
+      rigPage = {
+        status: 'skipped',
+        ...(rigPageSkipDetail ? { detail: rigPageSkipDetail } : {}),
+      };
     } else if (pointerPlan.action === 'unchanged') {
       rigPage = {
         status: 'unchanged',

--- a/packages/rig/src/cli/site.test.ts
+++ b/packages/rig/src/cli/site.test.ts
@@ -117,7 +117,11 @@ function makeDeps(
   env: NodeJS.ProcessEnv,
   cwd: string,
   shaToTxId: Map<string, string>,
-  opts: { interactive?: boolean; answer?: boolean; hasUploadBlob?: boolean } = {}
+  opts: {
+    interactive?: boolean;
+    answer?: boolean;
+    hasUploadBlob?: boolean;
+  } = {}
 ): Harness {
   const out: string[] = [];
   const err: string[] = [];
@@ -131,11 +135,14 @@ function makeDeps(
     confirm: async () => opts.answer ?? false,
   };
   const publisher: Publisher = {
-    getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 1n }),
+    getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1n }),
     uploadGitObject: async (u): Promise<UploadReceipt> => {
       gitUploads.push({ sha: u.sha, ...(u.path ? { path: u.path } : {}) });
       // A FRESH txid on re-upload (proves the manifest uses the new one).
-      return { txId: u.sha.padEnd(43, 'N'), feePaid: BigInt(u.body.length) * 10n };
+      return {
+        txId: u.sha.padEnd(43, 'N'),
+        feePaid: BigInt(u.body.length) * 10n,
+      };
     },
     publishEvent: async () => ({ eventId: 'e'.repeat(64), feePaid: 1n }),
   };
@@ -268,7 +275,14 @@ describe('site publish — execute', () => {
   it('--gateway overrides the printed URL host', async () => {
     const h = makeDeps(env, repoDir, fullMap);
     await runSite(
-      ['publish', '--relay', RELAY, '--gateway', 'https://arweave.net/', '--yes'],
+      [
+        'publish',
+        '--relay',
+        RELAY,
+        '--gateway',
+        'https://arweave.net/',
+        '--yes',
+      ],
       h.deps
     );
     expect(h.out.join('\n')).toContain(`https://arweave.net/${MANIFEST_TX}/`);
@@ -410,7 +424,10 @@ describe('site — usage + errors', () => {
     git(['commit', '-m', 'c'], bare);
     try {
       const h = makeDeps(env, bare, fullMap);
-      const code = await runSite(['publish', '--relay', RELAY, '--json'], h.deps);
+      const code = await runSite(
+        ['publish', '--relay', RELAY, '--json'],
+        h.deps
+      );
       expect(code).toBe(1);
       expect(JSON.parse(h.out.join('\n'))).toMatchObject({
         error: 'unconfigured_repo_address',

--- a/packages/rig/src/cli/site.ts
+++ b/packages/rig/src/cli/site.ts
@@ -27,9 +27,11 @@
  */
 
 import { parseArgs } from 'node:util';
-import { buildArweaveManifest, type ManifestEntry } from '../arweave-manifest.js';
+import {
+  buildArweaveManifest,
+  type ManifestEntry,
+} from '../arweave-manifest.js';
 import { resolveConflictingPath } from '../mime.js';
-import { flooredUploadFee } from '../publisher.js';
 import { GitRepoReader } from '../repo-reader.js';
 import type { RemoteState } from '../remote-state.js';
 import {
@@ -220,10 +222,7 @@ export async function runSite(args: string[], deps: SiteDeps): Promise<number> {
 // site publish
 // ---------------------------------------------------------------------------
 
-async function runSitePublish(
-  args: string[],
-  deps: SiteDeps
-): Promise<number> {
+async function runSitePublish(args: string[], deps: SiteDeps): Promise<number> {
   const { io } = deps;
 
   let flags: SiteFlags;
@@ -249,7 +248,12 @@ async function runSitePublish(
     const reader = new GitRepoReader(repoRoot);
 
     // ── Ref selection (single ref; default current branch) ─────────────────
-    const selected = await selectRefspecs(reader, flags.positionals, false, false);
+    const selected = await selectRefspecs(
+      reader,
+      flags.positionals,
+      false,
+      false
+    );
     if (selected.length !== 1) {
       throw new Error(
         `rig site publish builds ONE ref into a site — got ${selected.length} ` +
@@ -314,7 +318,8 @@ async function runSitePublish(
     }
 
     // ── Fallback (SPA) path resolution ─────────────────────────────────────
-    const fallbackPath = flags.fallback ?? (flags.spa ? flags.index : undefined);
+    const fallbackPath =
+      flags.fallback ?? (flags.spa ? flags.index : undefined);
     const pathSet = new Set(blobs.map((b) => b.path));
     if (fallbackPath !== undefined && !pathSet.has(fallbackPath)) {
       throw new Error(
@@ -345,10 +350,10 @@ async function runSitePublish(
     }
 
     // ── Fee estimate ───────────────────────────────────────────────────────
-    // Per-upload fees are floored at the store route's announced price
-    // (minUploadFee) — the same math the publisher claims per packet.
+    // An upload costs the store route's flat price whatever its size (ADR
+    // 0020) — the same figure the publisher claims per packet.
     const feeRates = await ctx.publisher.getFeeRates();
-    const { uploadFeePerByte, minUploadFee } = feeRates;
+    const { uploadFee } = feeRates;
     // Preview manifest with known/placeholder 43-char txids: byte-accurate for
     // the fee (every txid is 43 chars, so the real manifest is the same size).
     const previewEntries: ManifestEntry[] = blobs.map((b) => ({
@@ -367,19 +372,13 @@ async function runSitePublish(
     if (flags.forceReupload) {
       const { objects } = await reader.statObjects(uniqueShas);
       reuploadBytes = objects.reduce((sum, o) => sum + o.size, 0);
-      reuploadFee = objects.reduce(
-        (sum, o) => sum + flooredUploadFee(o.size, uploadFeePerByte, minUploadFee),
-        0n
-      );
+      reuploadFee = BigInt(objects.length) * uploadFee;
     }
-    const manifestFee = flooredUploadFee(
-      manifestBytes,
-      uploadFeePerByte,
-      minUploadFee
-    );
+    const manifestFee = uploadFee;
     const totalFee = manifestFee + reuploadFee;
 
-    const gateway = flags.gateway ?? deps.env['RIG_ARWEAVE_GATEWAY'] ?? DEFAULT_GATEWAY;
+    const gateway =
+      flags.gateway ?? deps.env['RIG_ARWEAVE_GATEWAY'] ?? DEFAULT_GATEWAY;
 
     const baseJson = (): Omit<SitePublishJson, 'executed'> => ({
       command: 'site publish',
@@ -401,10 +400,14 @@ async function runSitePublish(
     if (!flags.json) {
       io.out(`Site publish plan for ${ref} (repo ${repoId}):`);
       io.out(`  files:    ${blobs.length}`);
-      io.out(`  index:    ${flags.index}${pathSet.has(flags.index) ? '' : ' (missing!)'}`);
+      io.out(
+        `  index:    ${flags.index}${pathSet.has(flags.index) ? '' : ' (missing!)'}`
+      );
       if (fallbackPath) io.out(`  fallback: ${fallbackPath}`);
       if (flags.forceReupload) {
-        io.out(`  re-upload ${uniqueShas.length} blob(s), ${reuploadBytes} bytes (paid)`);
+        io.out(
+          `  re-upload ${uniqueShas.length} blob(s), ${reuploadBytes} bytes (paid)`
+        );
       }
       io.out(`  manifest: ${manifestBytes} bytes`);
       io.out(`  total fee: ${totalFee} base units`);
@@ -547,7 +550,12 @@ async function runSiteUrl(args: string[], deps: SiteDeps): Promise<number> {
     if (!repoId) throw new UnconfiguredRepoAddressError('repository id');
     const reader = new GitRepoReader(repoRoot);
 
-    const selected = await selectRefspecs(reader, flags.positionals, false, false);
+    const selected = await selectRefspecs(
+      reader,
+      flags.positionals,
+      false,
+      false
+    );
     if (selected.length !== 1) {
       throw new Error(
         `rig site url takes ONE ref — got ${selected.length} (${selected.join(', ')})`

--- a/packages/rig/src/cli/strict-json.test.ts
+++ b/packages/rig/src/cli/strict-json.test.ts
@@ -119,7 +119,7 @@ function emptyRemoteState(): RemoteState {
  */
 function makeNoisyStandalone(): { load: LoadStandalone } {
   const publisher: Publisher = {
-    getFeeRates: async () => ({ uploadFeePerByte: 10n, eventFee: 1n }),
+    getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1n }),
     uploadGitObject: async (upload) => ({
       txId: TX_ID,
       feePaid: BigInt(upload.body.length) * 10n,
@@ -157,7 +157,11 @@ function makeNoisyStandalone(): { load: LoadStandalone } {
           chain: 'evm',
           chainKey: 'evm:31337',
           address: '0x' + '1'.repeat(40),
-          native: { symbol: 'ETH', amount: '1000000000000000000', decimals: 18 },
+          native: {
+            symbol: 'ETH',
+            amount: '1000000000000000000',
+            decimals: 18,
+          },
           tokens: [{ symbol: 'USDC', amount: '424242', decimals: 6 }],
         },
       ],
@@ -169,8 +173,13 @@ function makeNoisyStandalone(): { load: LoadStandalone } {
       // Third-party stdout noise (vitest intercepts the global console, so
       // write the way console.log ultimately does: through the stream —
       // directly and via a stream-bound Console instance).
-      process.stdout.write('[Bootstrap] Connecting to wss://relay.example...\n');
-      new Console(process.stdout).log('[Bootstrap] Query filter:', '{"kinds":[10032]}');
+      process.stdout.write(
+        '[Bootstrap] Connecting to wss://relay.example...\n'
+      );
+      new Console(process.stdout).log(
+        '[Bootstrap] Query filter:',
+        '{"kinds":[10032]}'
+      );
       // The #264 discovery-fallback warning through the warn seam.
       options.warn(
         'rig: no payment-peer announce (kind:10032) found on wss://relay.example — falling back to the genesis peer seed'
@@ -221,12 +230,12 @@ async function run(
   const guard = redirectStdoutToStderr((text) => {
     stdoutChunks.push(text);
   });
-  const stderrSpy = vi
-    .spyOn(process.stderr, 'write')
-    .mockImplementation(((chunk: unknown) => {
-      stderrChunks.push(String(chunk));
-      return true;
-    }) as never);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
+    chunk: unknown
+  ) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  }) as never);
   try {
     const io = makeCliIo({
       jsonMode,
@@ -414,7 +423,14 @@ describe('strict --json stdout: every rig-owned command emits exactly one JSON d
     await writeToonConfig(repo, { repoId: 'demo', owner: OWNER });
     // Empty arweave map + --force-reupload → a pure estimate needs no uploads.
     const result = await run(
-      ['site', 'publish', '--relay', 'wss://relay.example', '--force-reupload', '--json'],
+      [
+        'site',
+        'publish',
+        '--relay',
+        'wss://relay.example',
+        '--force-reupload',
+        '--json',
+      ],
       { cwd: repo, loadStandalone: makeNoisyStandalone().load }
     );
     expect(result.code).toBe(0);
@@ -486,7 +502,10 @@ describe('strict --json stdout: every rig-owned command emits exactly one JSON d
   it('pr create --json --yes publishes a patch file and emits one envelope', async () => {
     const dir = makeTempDir('toon-rig-json-patch-');
     const patchPath = join(dir, 'series.patch');
-    writeFileSync(patchPath, 'From 1234 Mon Sep 17 00:00:00 2001\npatch body\n');
+    writeFileSync(
+      patchPath,
+      'From 1234 Mon Sep 17 00:00:00 2001\npatch body\n'
+    );
     const result = await run(
       [
         'pr',
@@ -604,7 +623,9 @@ describe('strict --json stdout: every rig-owned command emits exactly one JSON d
           undernameLimit: 10,
         }),
         ant: async () => ({
-          getRecords: async () => ({ '@': { transactionId: TX_ID, ttlSeconds: 3600 } }),
+          getRecords: async () => ({
+            '@': { transactionId: TX_ID, ttlSeconds: 3600 },
+          }),
           setBaseNameRecord: async () => ({ id: 'm' }),
           setUndernameRecord: async () => ({ id: 'm' }),
         }),
@@ -710,10 +731,13 @@ describe('strict --json stdout: the #278 read commands', () => {
   it('fetch --json emits one envelope (in a cloned repo, up to date)', async () => {
     const world = makeReadWorld();
     const cwd = makeTempDir('toon-rig-json-fetch-');
-    const cloned = await run(['clone', RELAY, `${OWNER}/demo`, 'cl', '--json'], {
-      cwd,
-      seams: world.seams,
-    });
+    const cloned = await run(
+      ['clone', RELAY, `${OWNER}/demo`, 'cl', '--json'],
+      {
+        cwd,
+        seams: world.seams,
+      }
+    );
     expect(cloned.code).toBe(0);
     const result = await run(['fetch', '--json'], {
       cwd: join(cwd, 'cl'),
@@ -770,7 +794,17 @@ describe('strict --json stdout: the #278 read commands', () => {
     expect(parseSingleJsonDoc(shown)).toMatchObject({ command: 'issue show' });
 
     const prList = await run(
-      ['pr', 'list', '--repo-id', 'demo', '--owner', OWNER, '--relay', RELAY, '--json'],
+      [
+        'pr',
+        'list',
+        '--repo-id',
+        'demo',
+        '--owner',
+        OWNER,
+        '--relay',
+        RELAY,
+        '--json',
+      ],
       { seams }
     );
     expect(prList.code).toBe(0);
@@ -853,18 +887,21 @@ describe('redirectStdoutToStderr', () => {
   it('reroutes every process.stdout write to stderr; only guard.write reaches stdout', () => {
     const real: string[] = [];
     const stderrChunks: string[] = [];
-    const stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation(((chunk: unknown) => {
-        stderrChunks.push(String(chunk));
-        return true;
-      }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
+      chunk: unknown
+    ) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as never);
     const guard = redirectStdoutToStderr((text) => {
       real.push(text);
     });
     try {
       process.stdout.write('[Bootstrap] direct write\n');
-      new Console(process.stdout).log('[Bootstrap] via console %s', 'formatted');
+      new Console(process.stdout).log(
+        '[Bootstrap] via console %s',
+        'formatted'
+      );
       guard.write('{"machine":true}\n');
     } finally {
       guard.restore();
@@ -872,7 +909,9 @@ describe('redirectStdoutToStderr', () => {
     }
     expect(real).toEqual(['{"machine":true}\n']);
     expect(stderrChunks.join('')).toContain('[Bootstrap] direct write');
-    expect(stderrChunks.join('')).toContain('[Bootstrap] via console formatted');
+    expect(stderrChunks.join('')).toContain(
+      '[Bootstrap] via console formatted'
+    );
   });
 
   it('restore() reinstates the original writer', () => {

--- a/packages/rig/src/index.ts
+++ b/packages/rig/src/index.ts
@@ -39,8 +39,27 @@ export {
   type UnsignedEvent,
 } from './nip34-events.js';
 
-export { GitError, GitRepoReader, type GitRef, type ObjectStat, type ObjectWithPath, type ReadGitObject, type ReadObjectsResult, type RepoRefs, type StatObjectsResult } from './repo-reader.js';
-export { fetchRemoteState, queryRelay, type FetchRemoteStateOptions, type NostrEvent, type NostrFilter, type RemoteState, type WebSocketFactory, type WebSocketLike } from './remote-state.js';
+export {
+  GitError,
+  GitRepoReader,
+  type GitRef,
+  type ObjectStat,
+  type ObjectWithPath,
+  type ReadGitObject,
+  type ReadObjectsResult,
+  type RepoRefs,
+  type StatObjectsResult,
+} from './repo-reader.js';
+export {
+  fetchRemoteState,
+  queryRelay,
+  type FetchRemoteStateOptions,
+  type NostrEvent,
+  type NostrFilter,
+  type RemoteState,
+  type WebSocketFactory,
+  type WebSocketLike,
+} from './remote-state.js';
 
 // The #278 read path: gateway download + verification, closure walking, the
 // clone/fetch collection engine, and repo materialization via git plumbing.
@@ -77,7 +96,6 @@ export {
 export { hexToNpub, npubToHex, ownerToHex } from './npub.js';
 
 export {
-  flooredUploadFee,
   type FeeRates,
   type GitObjectUpload,
   type PublishReceipt,

--- a/packages/rig/src/publisher.ts
+++ b/packages/rig/src/publisher.ts
@@ -83,41 +83,31 @@ export interface PublishReceipt {
   feePaid: bigint;
 }
 
-/** Fee rates used by `planPush` for the pre-push estimate. */
+/**
+ * Fee rates used by `planPush` for the pre-push estimate.
+ *
+ * Both figures are FLAT per packet. ADR 0020 (toon-client#452) removed
+ * byte-proportional pricing from the protocol: one handler, one price, and an
+ * app that wants to charge differently exposes more handlers. A 100-byte and
+ * a 100 KB upload to the same store route now cost the same, and the
+ * connector charges accordingly regardless of what a client computes — so
+ * there is no `uploadFeePerByte` to multiply and no floor to apply, because
+ * the route's price is the whole fee rather than a lower bound on one.
+ */
 export interface FeeRates {
-  /** Upload cost per body byte (smallest asset unit). */
-  uploadFeePerByte: bigint;
+  /**
+   * Flat cost per git-object/blob upload (smallest asset unit): the store
+   * destination's route price, as reported by the terminating connector's
+   * `GET /ilp/routes/price`. The connector gates every paid packet at that
+   * price, so an estimate built from it is exactly what a push pays.
+   */
+  uploadFee: bigint;
   /**
    * Flat cost per published event (smallest asset unit). Implementations
    * already fold any per-packet route-price floor into this flat value, so
    * estimates using it match the claims actually signed.
    */
   eventFee: bigint;
-  /**
-   * FLAT minimum per upload claim (smallest asset unit): the store
-   * destination's announced route price. The connector gates every paid
-   * packet at the destination route's price — a balance-proof claim
-   * advancing the channel by less is rejected (F06) — so each per-upload fee
-   * is `max(bytes × uploadFeePerByte, minUploadFee)`. Absent: no floor
-   * (pre-floor behavior, e.g. when the peer announces no capability prices).
-   */
-  minUploadFee?: bigint;
-}
-
-/**
- * Per-upload fee: `bytes × ratePerByte`, floored at `minFee` (the
- * destination's announced flat route price — see
- * {@link FeeRates.minUploadFee}). The single shared implementation keeps
- * every estimate site equal to what the publisher actually claims.
- */
-export function flooredUploadFee(
-  bytes: number,
-  ratePerByte: bigint,
-  minFee?: bigint
-): bigint {
-  const fee = BigInt(bytes) * ratePerByte;
-  const min = minFee ?? 0n;
-  return fee > min ? fee : min;
 }
 
 /**

--- a/packages/rig/src/push.test.ts
+++ b/packages/rig/src/push.test.ts
@@ -18,7 +18,6 @@ import { join } from 'node:path';
 import { EMPTY_BLOB_SHA, hashGitObject, MAX_OBJECT_SIZE } from './objects.js';
 import type { UnsignedEvent } from './nip34-events.js';
 import {
-  flooredUploadFee,
   type FeeRates,
   type GitObjectUpload,
   type PublishReceipt,
@@ -55,7 +54,7 @@ let allObjects: string[] = [];
 
 const REPO_ID = 'push-fixture';
 const RELAYS = ['wss://relay.test'];
-const FEE_RATES: FeeRates = { uploadFeePerByte: 10n, eventFee: 500n };
+const FEE_RATES: FeeRates = { uploadFee: 1000n, eventFee: 500n };
 const UNKNOWN_SHA = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
 
 function git(args: string[], cwd: string): string {
@@ -192,7 +191,7 @@ class MockPublisher implements Publisher {
     this.uploads.push(upload);
     return {
       txId: `tx-${upload.sha}`,
-      feePaid: BigInt(upload.body.length) * FEE_RATES.uploadFeePerByte,
+      feePaid: FEE_RATES.uploadFee,
     };
   }
 
@@ -201,7 +200,10 @@ class MockPublisher implements Publisher {
     relayUrls: string[]
   ): Promise<PublishReceipt> {
     this.published.push({ event, relayUrls });
-    return { eventId: `ev-${this.published.length}`, feePaid: FEE_RATES.eventFee };
+    return {
+      eventId: `ev-${this.published.length}`,
+      feePaid: FEE_RATES.eventFee,
+    };
   }
 }
 
@@ -241,16 +243,20 @@ describe('planPush', () => {
     expect(plan.newRefs['refs/heads/feature/x']).toBe(featureCommit);
     expect(plan.newRefs['refs/tags/v1']).toBe(tagSha);
 
-    // Fees: Σ bytes × rate + 2 events (announce + refs).
+    // Fees: one flat route price per object + 2 events (announce + refs).
     const totalBytes = plan.objects.reduce((sum, o) => sum + o.size, 0);
     expect(plan.estimate.objectCount).toBe(plan.objects.length);
     expect(plan.estimate.totalObjectBytes).toBe(totalBytes);
-    expect(plan.estimate.uploadFee).toBe(BigInt(totalBytes) * 10n);
+    const uploadFees = BigInt(plan.objects.length) * FEE_RATES.uploadFee;
+    expect(plan.estimate.uploadFee).toBe(uploadFees);
     expect(plan.announceNeeded).toBe(true);
     expect(plan.estimate.eventCount).toBe(2);
     expect(plan.estimate.eventFees).toBe(1000n);
-    expect(plan.estimate.totalFee).toBe(BigInt(totalBytes) * 10n + 1000n);
-    expect(plan.announcement).toEqual({ name: 'Push Fixture', description: 'a test repo' });
+    expect(plan.estimate.totalFee).toBe(uploadFees + 1000n);
+    expect(plan.announcement).toEqual({
+      name: 'Push Fixture',
+      description: 'a test repo',
+    });
 
     // Sizes are real: the README blob's size matches its content.
     const readmeSha = git(['rev-parse', 'main:README.md'], repoDir);
@@ -286,9 +292,7 @@ describe('planPush', () => {
     ]);
 
     // Delta = objects of commit2 not reachable from commit1.
-    const expected = allObjects.filter(
-      (sha) => !commit1Objects.includes(sha)
-    );
+    const expected = allObjects.filter((sha) => !commit1Objects.includes(sha));
     const expectedMain = reachableObjects([commit2, `^${commit1}`], repoDir);
     expect(plan.objects.map((o) => o.sha).sort()).toEqual(
       [...new Set(expectedMain)].sort()
@@ -480,9 +484,7 @@ describe('planPush', () => {
     const nonTipIndexes = plan.objects
       .map((o, i) => (tips.has(o.sha) ? -1 : i))
       .filter((i) => i !== -1);
-    expect(Math.min(...tipIndexes)).toBeGreaterThan(
-      Math.max(...nonTipIndexes)
-    );
+    expect(Math.min(...tipIndexes)).toBeGreaterThan(Math.max(...nonTipIndexes));
     for (const o of plan.objects) {
       expect(o.isRefTip).toBe(tips.has(o.sha));
     }
@@ -518,9 +520,7 @@ describe('executePush', () => {
     expect(publisher.uploads.map((u) => u.sha)).toEqual(
       plan.objects.map((o) => o.sha)
     );
-    expect(publisher.uploads.at(-1)!.sha).toBe(
-      plan.objects.at(-1)!.sha
-    );
+    expect(publisher.uploads.at(-1)!.sha).toBe(plan.objects.at(-1)!.sha);
     expect(plan.objects.at(-1)!.isRefTip).toBe(true);
     for (const upload of publisher.uploads) {
       expect(hashGitObject(upload.type, upload.body).sha).toBe(upload.sha);
@@ -600,9 +600,9 @@ describe('executePush', () => {
     const arweaveTags = new Map(
       tagValues(refsEvent, 'arweave').map(([k, v]) => [k, v])
     );
-    expect(
-      arweaveTags.get('1111111111111111111111111111111111111111')
-    ).toBe('ancient-tx');
+    expect(arweaveTags.get('1111111111111111111111111111111111111111')).toBe(
+      'ancient-tx'
+    );
     for (const sha of commit1Objects) {
       expect(arweaveTags.get(sha)).toBe(`old-${sha}`);
     }
@@ -660,16 +660,18 @@ describe('executePush', () => {
     // …but they still appear in the result (skipped, fee 0) and the map.
     for (const sha of paid.keys()) {
       const step = result.uploads.find((u) => u.sha === sha)!;
-      expect(step).toMatchObject({ txId: `tx-${sha}`, feePaid: 0n, skipped: true });
+      expect(step).toMatchObject({
+        txId: `tx-${sha}`,
+        feePaid: 0n,
+        skipped: true,
+      });
       expect(result.arweaveMap.get(sha)).toBe(`tx-${sha}`);
     }
 
-    // Fees: only the remaining uploads + both events were paid.
-    const skippedBytes = plan.objects
-      .filter((o) => paid.has(o.sha))
-      .reduce((sum, o) => sum + o.size, 0);
+    // Fees: only the remaining uploads + both events were paid. A skipped
+    // upload costs one whole route price now, not its bytes' worth.
     expect(result.totalFeePaid).toBe(
-      plan.estimate.totalFee - BigInt(skippedBytes) * FEE_RATES.uploadFeePerByte
+      plan.estimate.totalFee - BigInt(paid.size) * FEE_RATES.uploadFee
     );
 
     // Announce still happened exactly once across the two attempts.
@@ -733,17 +735,18 @@ describe('empty-blob handling', () => {
     ]);
     expect(plan.estimate.skippedEmptyCount).toBe(1);
     // The non-empty sibling blob IS uploaded.
-    const filledSha = hashGitObject(
-      'blob',
-      Buffer.from('not empty\n')
-    ).sha;
+    const filledSha = hashGitObject('blob', Buffer.from('not empty\n')).sha;
     expect(uploadShas).toContain(filledSha);
     // The empty blob has no txId and is never added to the arweave map.
     expect(plan.knownShaToTxId.has(EMPTY_BLOB_SHA)).toBe(false);
-    // Its zero body contributes nothing to the fee.
+    // It is excluded from the upload set, so it is not one of the packets
+    // priced — the saving is a whole route price, not its (zero) bytes.
     const totalBytes = plan.objects.reduce((sum, o) => sum + o.size, 0);
     expect(plan.estimate.totalObjectBytes).toBe(totalBytes);
-    expect(plan.estimate.uploadFee).toBe(BigInt(totalBytes) * 10n);
+    expect(plan.objects.some((o) => o.sha === EMPTY_BLOB_SHA)).toBe(false);
+    expect(plan.estimate.uploadFee).toBe(
+      BigInt(plan.objects.length) * FEE_RATES.uploadFee
+    );
   });
 
   it('executePush never uploads the empty blob (Publisher.uploadGitObject not called for it)', async () => {
@@ -792,7 +795,9 @@ describe('empty-blob handling', () => {
     expect(plan.skippedEmptyObjects).toHaveLength(0);
     expect(plan.estimate.skippedEmptyCount).toBe(0);
     // Sanity: the branch really does carry the empty tree.
-    expect(reachableObjects([emptyTreeCommit], repoDir)).toContain(emptyTreeSha);
+    expect(reachableObjects([emptyTreeCommit], repoDir)).toContain(
+      emptyTreeSha
+    );
   });
 
   it('pushes the non-empty objects and skips ONLY the empty one', async () => {
@@ -826,35 +831,24 @@ describe('empty-blob handling', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Route-price floors — estimate/actual parity
+// Flat route pricing — estimate/actual parity
 // ---------------------------------------------------------------------------
 
-describe('route-price floors (estimate === claims parity)', () => {
-  /** Devnet-shaped rates: 10/byte uploads floored at a flat 1000 per packet. */
-  const FLOORED_RATES: FeeRates = {
-    uploadFeePerByte: 10n,
-    eventFee: 1000n, // flat per-event fee arrives pre-floored from getFeeRates
-    minUploadFee: 1000n,
-  };
+describe('flat route pricing (estimate === claims parity)', () => {
+  /** Devnet-shaped rates: a flat 1000 per packet, upload or event alike. */
+  const FLAT_RATES: FeeRates = { uploadFee: 1000n, eventFee: 1000n };
 
-  /** Publisher paying the EXACT per-packet fees a floored publisher claims. */
-  class FlooredMockPublisher extends MockPublisher {
+  /** Publisher paying the EXACT per-packet fees a flat-priced publisher claims. */
+  class FlatMockPublisher extends MockPublisher {
     override async getFeeRates(): Promise<FeeRates> {
-      return FLOORED_RATES;
+      return FLAT_RATES;
     }
 
     override async uploadGitObject(
       upload: GitObjectUpload
     ): Promise<UploadReceipt> {
       const receipt = await super.uploadGitObject(upload);
-      return {
-        ...receipt,
-        feePaid: flooredUploadFee(
-          upload.body.length,
-          FLOORED_RATES.uploadFeePerByte,
-          FLOORED_RATES.minUploadFee
-        ),
-      };
+      return { ...receipt, feePaid: FLAT_RATES.uploadFee };
     }
 
     override async publishEvent(
@@ -862,34 +856,44 @@ describe('route-price floors (estimate === claims parity)', () => {
       relayUrls: string[]
     ): Promise<PublishReceipt> {
       const receipt = await super.publishEvent(event, relayUrls);
-      return { ...receipt, feePaid: FLOORED_RATES.eventFee };
+      return { ...receipt, feePaid: FLAT_RATES.eventFee };
     }
   }
 
-  it('planPush floors each object at minUploadFee', async () => {
+  it('planPush prices every object at the route price, whatever its size', async () => {
     const plan = await planPush({
       repoReader: reader,
       remoteState: cannedRemote(),
-      feeRates: FLOORED_RATES,
+      feeRates: FLAT_RATES,
       repoId: REPO_ID,
       refs: ['refs/heads/main'],
     });
 
-    // The fixture has small objects (< 100 bytes), so the floor really bites.
-    const floored = plan.objects.filter((o) => BigInt(o.size) * 10n < 1000n);
-    expect(floored.length).toBeGreaterThan(0);
+    // Objects of different sizes cost the same — that IS the ADR 0020 change.
+    const sizes = new Set(plan.objects.map((o) => o.size));
+    expect(sizes.size).toBeGreaterThan(1);
 
-    const expectedUploadFee = plan.objects.reduce(
-      (sum, o) => sum + flooredUploadFee(o.size, 10n, 1000n),
-      0n
-    );
-    expect(plan.estimate.uploadFee).toBe(expectedUploadFee);
-    // Strictly more than the unfloored Σ bytes × rate.
-    expect(plan.estimate.uploadFee).toBeGreaterThan(
-      BigInt(plan.estimate.totalObjectBytes) * 10n
+    expect(plan.estimate.uploadFee).toBe(
+      BigInt(plan.objects.length) * FLAT_RATES.uploadFee
     );
     expect(plan.estimate.totalFee).toBe(
-      expectedUploadFee + BigInt(plan.estimate.eventCount) * 1000n
+      plan.estimate.uploadFee + BigInt(plan.estimate.eventCount) * 1000n
+    );
+  });
+
+  it('a 1-byte and a 100 KB object are quoted the same', async () => {
+    const plan = await planPush({
+      repoReader: reader,
+      remoteState: cannedRemote(),
+      feeRates: FLAT_RATES,
+      repoId: REPO_ID,
+      refs: ['refs/heads/main'],
+    });
+    // Size no longer appears in the fee at all: the estimate is a packet
+    // count times a price, and totalObjectBytes is reported but unpriced.
+    expect(plan.estimate.uploadFee % FLAT_RATES.uploadFee).toBe(0n);
+    expect(plan.estimate.uploadFee / FLAT_RATES.uploadFee).toBe(
+      BigInt(plan.estimate.objectCount)
     );
   });
 
@@ -897,11 +901,11 @@ describe('route-price floors (estimate === claims parity)', () => {
     const plan = await planPush({
       repoReader: reader,
       remoteState: cannedRemote(),
-      feeRates: FLOORED_RATES,
+      feeRates: FLAT_RATES,
       repoId: REPO_ID,
       refs: ['refs/heads/main'],
     });
-    const publisher = new FlooredMockPublisher();
+    const publisher = new FlatMockPublisher();
     const result = await executePush({
       plan,
       publisher,
@@ -910,18 +914,5 @@ describe('route-price floors (estimate === claims parity)', () => {
       relayUrls: RELAYS,
     });
     expect(result.totalFeePaid).toBe(plan.estimate.totalFee);
-  });
-
-  it('rates without a floor keep the historical Σ bytes × rate estimate', async () => {
-    const plan = await planPush({
-      repoReader: reader,
-      remoteState: cannedRemote(),
-      feeRates: FEE_RATES, // no minUploadFee
-      repoId: REPO_ID,
-      refs: ['refs/heads/main'],
-    });
-    expect(plan.estimate.uploadFee).toBe(
-      BigInt(plan.estimate.totalObjectBytes) * FEE_RATES.uploadFeePerByte
-    );
   });
 });

--- a/packages/rig/src/push.ts
+++ b/packages/rig/src/push.ts
@@ -30,7 +30,6 @@ import {
   type GitObjectType,
 } from './objects.js';
 import {
-  flooredUploadFee,
   type FeeRates,
   type PublishReceipt,
   type Publisher,
@@ -85,9 +84,7 @@ export class OversizeObjectsError extends Error {
   ) {
     super(
       `${objects.length} object(s) exceed the ${MAX_OBJECT_SIZE} byte upload limit: ` +
-        objects
-          .map((o) => `${o.path ?? o.sha} (${o.size} bytes)`)
-          .join(', ')
+        objects.map((o) => `${o.path ?? o.sha} (${o.size} bytes)`).join(', ')
     );
     this.name = 'OversizeObjectsError';
   }
@@ -137,7 +134,7 @@ export interface PushFeeEstimate {
   objectCount: number;
   /** Total bytes across all planned object bodies. */
   totalObjectBytes: number;
-  /** Σ max(size × uploadFeePerByte, minUploadFee) — smallest asset unit. */
+  /** objectCount × the store route's flat price — smallest asset unit. */
   uploadFee: bigint;
   /** Number of events to publish (refs event + announcement on first push). */
   eventCount: number;
@@ -258,11 +255,21 @@ export async function planPush(options: PlanPushOptions): Promise<PushPlan> {
   for (const ref of selected) {
     const remoteSha = remoteState.refs.get(ref.refname) ?? null;
     if (remoteSha === null) {
-      refUpdates.push({ refname: ref.refname, localSha: ref.sha, remoteSha, kind: 'new' });
+      refUpdates.push({
+        refname: ref.refname,
+        localSha: ref.sha,
+        remoteSha,
+        kind: 'new',
+      });
       continue;
     }
     if (remoteSha === ref.sha) {
-      refUpdates.push({ refname: ref.refname, localSha: ref.sha, remoteSha, kind: 'up-to-date' });
+      refUpdates.push({
+        refname: ref.refname,
+        localSha: ref.sha,
+        remoteSha,
+        kind: 'up-to-date',
+      });
       continue;
     }
     let fastForward = false;
@@ -275,9 +282,19 @@ export async function planPush(options: PlanPushOptions): Promise<PushPlan> {
       fastForward = false;
     }
     if (fastForward) {
-      refUpdates.push({ refname: ref.refname, localSha: ref.sha, remoteSha, kind: 'fast-forward' });
+      refUpdates.push({
+        refname: ref.refname,
+        localSha: ref.sha,
+        remoteSha,
+        kind: 'fast-forward',
+      });
     } else if (force) {
-      refUpdates.push({ refname: ref.refname, localSha: ref.sha, remoteSha, kind: 'forced' });
+      refUpdates.push({
+        refname: ref.refname,
+        localSha: ref.sha,
+        remoteSha,
+        kind: 'forced',
+      });
     } else {
       rejected.push({ refname: ref.refname, localSha: ref.sha, remoteSha });
     }
@@ -369,17 +386,14 @@ export async function planPush(options: PlanPushOptions): Promise<PushPlan> {
   }
 
   // 6. Fee estimate. ---------------------------------------------------------
-  // Per-object pricing, each upload floored at the destination route's
-  // announced price (`minUploadFee`) — the exact same math the publisher
-  // claims per packet, so the confirm table always equals what is paid.
+  // A price is FLAT per packet (ADR 0020), so an upload costs the store
+  // route's price whatever its size: one price × one packet per object, the
+  // exact same figure the publisher claims per packet, so the confirm table
+  // always equals what is paid. `totalObjectBytes` is still reported — it is
+  // what a user wants to see about a push — but it no longer prices it.
   const announceNeeded = !remoteState.announced;
   const totalObjectBytes = objects.reduce((sum, o) => sum + o.size, 0);
-  const uploadFee = objects.reduce(
-    (sum, o) =>
-      sum +
-      flooredUploadFee(o.size, feeRates.uploadFeePerByte, feeRates.minUploadFee),
-    0n
-  );
+  const uploadFee = BigInt(objects.length) * feeRates.uploadFee;
   const eventCount = 1 + (announceNeeded ? 1 : 0);
   const eventFees = BigInt(eventCount) * feeRates.eventFee;
 

--- a/packages/rig/src/routes.ts
+++ b/packages/rig/src/routes.ts
@@ -55,7 +55,7 @@ export interface GitEstimateRequest {
 export interface GitFeeEstimate {
   objectCount: number;
   totalObjectBytes: number;
-  /** Σ max(size × uploadFeePerByte, per-upload route-price floor). */
+  /** objectCount × the store route's flat price. */
   uploadFee: string;
   /** Events to publish (refs event + announcement on first push). */
   eventCount: number;

--- a/packages/rig/src/standalone/standalone-publisher.test.ts
+++ b/packages/rig/src/standalone/standalone-publisher.test.ts
@@ -17,10 +17,12 @@ import {
   type ChannelMapRecord,
   type PersistedChannelContext,
 } from './channel-map.js';
-import { DaemonIdentityConflictError, StandaloneLockError } from './nonce-guard.js';
+import {
+  DaemonIdentityConflictError,
+  StandaloneLockError,
+} from './nonce-guard.js';
 import {
   StandalonePublisher,
-  StandalonePublishError,
   deriveRouteDestinations,
   extractArweaveTxId,
   type SignedNostrEvent,
@@ -30,12 +32,17 @@ import {
 const PUBKEY = 'c'.repeat(64);
 const TX_ID = 'A'.repeat(43); // valid 43-char base64url Arweave tx id
 
-/** Base64 FULFILL data carrying the proxy's verbatim HTTP store response. */
-function httpFulfill(body: string, status = 200): string {
-  const message =
-    `HTTP/1.1 ${status} ${status === 200 ? 'OK' : 'Bad Request'}\r\n` +
-    `content-length: ${Buffer.byteLength(body)}\r\n\r\n${body}`;
-  return Buffer.from(message, 'utf8').toString('base64');
+/**
+ * The store's answer as the terminating connector now seals it: a response
+ * envelope (ADR 0018), which `publishEvent` opens and hands back verbatim.
+ * There is no plaintext-HTTP shape on this wire any more.
+ */
+function storeAnswer(body: string, status = 200) {
+  return {
+    status,
+    headers: [['content-type', 'application/json']] as [string, string][],
+    body: new TextEncoder().encode(body),
+  };
 }
 
 interface MockCalls {
@@ -97,7 +104,7 @@ function mockClient(overrides?: {
         overrides?.publishResult?.(event) ?? {
           success: true,
           eventId: event.id,
-          data: httpFulfill(JSON.stringify({ accept: true, txId: TX_ID })),
+          response: storeAnswer(JSON.stringify({ accept: true, txId: TX_ID })),
         }
       );
     },
@@ -112,10 +119,11 @@ const noDaemon = vi.fn(async () => {
 
 /** fetch mock: daemon /status answering with the given pubkey. */
 function daemonWith(pubkey: string): typeof fetch {
-  return vi.fn(async () =>
-    new Response(JSON.stringify({ identity: { nostrPubkey: pubkey } }), {
-      status: 200,
-    })
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify({ identity: { nostrPubkey: pubkey } }), {
+        status: 200,
+      })
   ) as unknown as typeof fetch;
 }
 
@@ -181,20 +189,25 @@ describe('StandalonePublisher', () => {
   });
 
   describe('getFeeRates', () => {
-    it('returns the daemon-convention defaults (eventFee 1, 10/byte uploads)', async () => {
+    it('reports 0 for an upload when no store route price is known', async () => {
+      // This class never invents a rate: with nothing announced it quotes 0
+      // and lets the connector be the one to refuse (F06).
       const { client } = mockClient();
       const publisher = build(client);
       await expect(publisher.getFeeRates()).resolves.toEqual({
-        uploadFeePerByte: 10n,
+        uploadFee: 0n,
         eventFee: 1n,
       });
     });
 
-    it('honours configured overrides', async () => {
+    it('honours the configured event fee and the announced store price', async () => {
       const { client } = mockClient();
-      const publisher = build(client, { eventFee: 7n, uploadFeePerByte: 3n });
+      const publisher = build(client, {
+        eventFee: 7n,
+        routePrices: { store: 3n },
+      });
       await expect(publisher.getFeeRates()).resolves.toEqual({
-        uploadFeePerByte: 3n,
+        uploadFee: 3n,
         eventFee: 7n,
       });
     });
@@ -261,12 +274,12 @@ describe('StandalonePublisher', () => {
       repoId: 'toon-meta',
     };
 
-    it('publishes a kind:5094 Git-SHA/Git-Type/Repo-tagged store write, bytes × rate fee, one claim', async () => {
+    it('publishes a kind:5094 Git-SHA/Git-Type/Repo-tagged store write at the flat route price, one claim', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n });
+      const publisher = build(client, { routePrices: { store: 1000n } });
 
       const receipt = await publisher.uploadGitObject(upload);
-      const expectedFee = BigInt(upload.body.length) * 10n;
+      const expectedFee = 1000n;
       expect(receipt).toEqual({ txId: TX_ID, feePaid: expectedFee });
 
       expect(calls.claims).toEqual([
@@ -290,12 +303,17 @@ describe('StandalonePublisher', () => {
       await publisher.stop();
     });
 
-    it('decodes a legacy bare-base64 txId FULFILL (non-proxy providers)', async () => {
+    it('reads the txId out of the answer’s `data` field when `txId` is absent', async () => {
       const { client } = mockClient({
         publishResult: (event) => ({
           success: true,
           eventId: event.id,
-          data: Buffer.from(TX_ID, 'utf8').toString('base64'),
+          response: storeAnswer(
+            JSON.stringify({
+              accept: true,
+              data: Buffer.from(TX_ID, 'utf8').toString('base64'),
+            })
+          ),
         }),
       });
       const publisher = build(client);
@@ -323,7 +341,7 @@ describe('StandalonePublisher', () => {
         publishResult: (event) => ({
           success: true,
           eventId: event.id,
-          data: httpFulfill(
+          response: storeAnswer(
             JSON.stringify({ accept: false, error: 'disk full' })
           ),
         }),
@@ -335,13 +353,13 @@ describe('StandalonePublisher', () => {
       await publisher.stop();
     });
 
-    it('throws when the FULFILL has no data', async () => {
+    it('throws when the FULFILL carried no sealed response', async () => {
       const { client } = mockClient({
         publishResult: (event) => ({ success: true, eventId: event.id }),
       });
       const publisher = build(client);
       await expect(publisher.uploadGitObject(upload)).rejects.toThrow(
-        /no data/
+        /no sealed response/
       );
       await publisher.stop();
     });
@@ -376,7 +394,7 @@ describe('StandalonePublisher', () => {
   describe('uploadBlob (#368 — raw manifest, no git envelope)', () => {
     it('publishes a kind:5094 with i/bid/output/Repo tags (no Git-* tags), one claim', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n });
+      const publisher = build(client, { routePrices: { store: 1000n } });
       const body = Buffer.from('{"manifest":"arweave/paths"}');
 
       const receipt = await publisher.uploadBlob({
@@ -384,7 +402,7 @@ describe('StandalonePublisher', () => {
         contentType: 'application/x.arweave-manifest+json',
         repoId: 'toon-meta',
       });
-      const expectedFee = BigInt(body.length) * 10n;
+      const expectedFee = 1000n;
       expect(receipt).toEqual({ txId: TX_ID, feePaid: expectedFee });
       expect(calls.claims).toEqual([
         { channelId: 'channel-1', amount: expectedFee },
@@ -413,9 +431,9 @@ describe('StandalonePublisher', () => {
         body: Buffer.from('x'),
         contentType: 'text/plain',
       });
-      expect(
-        calls.publishes[0]!.event.tags.some((t) => t[0] === 'Repo')
-      ).toBe(false);
+      expect(calls.publishes[0]!.event.tags.some((t) => t[0] === 'Repo')).toBe(
+        false
+      );
       await publisher.stop();
     });
 
@@ -433,7 +451,7 @@ describe('StandalonePublisher', () => {
     });
   });
 
-  describe('route-price floors (the connector gates packets at the route price — F06)', () => {
+  describe('flat route pricing (the connector gates packets at the route price — F06)', () => {
     const gitUpload = (bytes: number) => ({
       sha: '1234567890abcdef1234567890abcdef12345678',
       type: 'blob' as const,
@@ -443,15 +461,15 @@ describe('StandalonePublisher', () => {
     /** The devnet announce's flat prices: 1000 per packet on both routes. */
     const routePrices = { publish: 1000n, store: 1000n };
 
-    it('floors a small upload claim at the store route price (74 B × 10 = 740 → 1000)', async () => {
+    it('charges the store route price for a small upload', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n, routePrices });
+      const publisher = build(client, { routePrices });
       const receipt = await publisher.uploadGitObject(gitUpload(74));
       expect(receipt.feePaid).toBe(1000n);
       expect(calls.claims).toEqual([{ channelId: 'channel-1', amount: 1000n }]);
       const pub = calls.publishes[0]!;
       expect(pub.options?.ilpAmount).toBe(1000n);
-      // The bid rides the floored fee too — the store is paid what it is bid.
+      // The bid rides the same fee — the store is paid what it is bid.
       expect(pub.event.tags.find((t) => t[0] === 'bid')).toEqual([
         'bid',
         '1000',
@@ -460,20 +478,20 @@ describe('StandalonePublisher', () => {
       await publisher.stop();
     });
 
-    it('leaves a large upload claim unchanged (1835 B × 10 = 18350 > 1000)', async () => {
+    it('charges a 25× larger upload exactly the same — the ADR 0020 change', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n, routePrices });
+      const publisher = build(client, { routePrices });
       const receipt = await publisher.uploadGitObject(gitUpload(1835));
-      expect(receipt.feePaid).toBe(18350n);
-      expect(calls.claims).toEqual([
-        { channelId: 'channel-1', amount: 18350n },
-      ]);
+      // Under per-byte pricing this was 18350. A price is now flat per
+      // handler, so size does not enter the fee at all.
+      expect(receipt.feePaid).toBe(1000n);
+      expect(calls.claims).toEqual([{ channelId: 'channel-1', amount: 1000n }]);
       await publisher.stop();
     });
 
-    it('floors a raw-blob upload claim the same way', async () => {
+    it('charges a raw-blob upload the same way', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n, routePrices });
+      const publisher = build(client, { routePrices });
       const receipt = await publisher.uploadBlob({
         body: Buffer.alloc(74, 0x61),
         contentType: 'text/html',
@@ -493,46 +511,40 @@ describe('StandalonePublisher', () => {
       await publisher.stop();
     });
 
-    it('keeps pre-floor behavior when no route prices are known (740 / 0)', async () => {
+    it('quotes 0 rather than a made-up rate when no price is known', async () => {
       const { client, calls } = mockClient();
-      const publisher = build(client, { uploadFeePerByte: 10n, eventFee: 0n });
+      const publisher = build(client, { eventFee: 0n });
       const receipt = await publisher.uploadGitObject(gitUpload(74));
-      expect(receipt.feePaid).toBe(740n);
+      expect(receipt.feePaid).toBe(0n);
       const publishReceipt = await publisher.publishEvent(EVENT, []);
       expect(publishReceipt.feePaid).toBe(0n);
       expect(calls.claims).toEqual([
-        { channelId: 'channel-1', amount: 740n },
+        { channelId: 'channel-1', amount: 0n },
         { channelId: 'channel-1', amount: 0n },
       ]);
       await publisher.stop();
     });
 
-    it('getFeeRates folds the floors in (estimate === claims)', async () => {
+    it('getFeeRates reports both flat prices (estimate === claims)', async () => {
       const { client } = mockClient();
-      const publisher = build(client, {
-        eventFee: 1n,
-        uploadFeePerByte: 10n,
-        routePrices,
-      });
+      const publisher = build(client, { eventFee: 1n, routePrices });
       await expect(publisher.getFeeRates()).resolves.toEqual({
-        uploadFeePerByte: 10n,
+        uploadFee: 1000n, // the store route price, whole
         eventFee: 1000n, // flat fee pre-floored at the publish route price
-        minUploadFee: 1000n, // per-upload floor (store route price)
       });
       await publisher.stop();
     });
 
-    it('a floor only applies to its own route (publish-only price)', async () => {
+    it('a price only applies to its own route (publish-only price)', async () => {
       const { client, calls } = mockClient();
       const publisher = build(client, {
-        uploadFeePerByte: 10n,
         eventFee: 1n,
         routePrices: { publish: 1000n },
       });
       await publisher.uploadGitObject(gitUpload(74));
-      expect(calls.claims).toEqual([{ channelId: 'channel-1', amount: 740n }]);
+      expect(calls.claims).toEqual([{ channelId: 'channel-1', amount: 0n }]);
       await expect(publisher.getFeeRates()).resolves.toEqual({
-        uploadFeePerByte: 10n,
+        uploadFee: 0n,
         eventFee: 1000n,
       });
       await publisher.stop();
@@ -837,9 +849,7 @@ describe('StandalonePublisher', () => {
 
       // ONE channel total: run 2 resumed instead of opening on-chain.
       expect(callsB.onChainOpens).toBe(0);
-      expect(callsB.claims).toEqual([
-        { channelId: '0xchannel-1', amount: 1n },
-      ]);
+      expect(callsB.claims).toEqual([{ channelId: '0xchannel-1', amount: 1n }]);
       // trackChannel got the persisted chain context — the client rehydrates
       // the nonce/cumulative watermark from channels.json off exactly this
       // call (covered by @toon-protocol/client's ChannelManager tests).
@@ -1315,29 +1325,33 @@ describe('StandalonePublisher', () => {
 });
 
 describe('extractArweaveTxId', () => {
-  it('rejects an invalid legacy payload', () => {
-    expect(() =>
-      extractArweaveTxId(Buffer.from('nope', 'utf8').toString('base64'))
-    ).toThrow(StandalonePublishError);
+  const answer = (status: number, body: string) => ({
+    status,
+    headers: [['content-type', 'application/json']] as [string, string][],
+    body: new TextEncoder().encode(body),
+  });
+
+  it('rejects a body that is not JSON', () => {
+    expect(() => extractArweaveTxId(answer(200, 'nope'))).toThrow(
+      /not valid JSON/
+    );
   });
 
   it('reads the txId from the data-field fallback', () => {
-    const body = JSON.stringify({
-      accept: true,
-      data: Buffer.from(TX_ID, 'utf8').toString('base64'),
-    });
-    const data = Buffer.from(
-      `HTTP/1.1 200 OK\r\ncontent-length: ${Buffer.byteLength(body)}\r\n\r\n${body}`,
-      'utf8'
-    ).toString('base64');
-    expect(extractArweaveTxId(data)).toBe(TX_ID);
+    expect(
+      extractArweaveTxId(
+        answer(
+          200,
+          JSON.stringify({
+            accept: true,
+            data: Buffer.from(TX_ID, 'utf8').toString('base64'),
+          })
+        )
+      )
+    ).toBe(TX_ID);
   });
 
   it('rejects a non-2xx store response', () => {
-    const data = Buffer.from(
-      'HTTP/1.1 500 Internal Server Error\r\ncontent-length: 4\r\n\r\noops',
-      'utf8'
-    ).toString('base64');
-    expect(() => extractArweaveTxId(data)).toThrow(/HTTP 500/);
+    expect(() => extractArweaveTxId(answer(500, 'oops'))).toThrow(/HTTP 500/);
   });
 });

--- a/packages/rig/src/standalone/standalone-publisher.ts
+++ b/packages/rig/src/standalone/standalone-publisher.ts
@@ -36,12 +36,11 @@ import type {
   SignedBalanceProof,
   ToonClientConfig,
 } from '@toon-protocol/client';
-import { ToonClient, parseFulfillHttp } from '@toon-protocol/client';
+import { ToonClient, extractArweaveTxId } from '@toon-protocol/client';
 import { MAX_OBJECT_SIZE } from '../objects.js';
 import { contentTypeForPath, DEFAULT_CONTENT_TYPE } from '../mime.js';
 import type { UnsignedEvent } from '../nip34-events.js';
 import {
-  flooredUploadFee,
   type BlobUpload,
   type FeeRates,
   type GitObjectUpload,
@@ -174,17 +173,21 @@ export interface StandalonePublisherOptions {
   channelDestination?: string;
   /** Flat fee per published event (daemon `feePerEvent` convention). Default 1n. */
   eventFee?: bigint;
-  /** Upload fee per object body byte (seed pipeline's bid rate). Default 10n. */
-  uploadFeePerByte?: bigint;
   /**
-   * FLAT per-packet route prices the payment peer announces for the
-   * publish/store destinations (kind:10032 `capabilities` — e.g.
-   * `{capability:'os.publish', address:'g.proxy.relay', price:'1000'}`).
-   * The connector gates every paid packet at the destination route's price:
-   * a balance-proof claim advancing the channel by less is rejected (F06).
-   * Applied as a FLOOR on the computed per-packet fee — `publish` floors
-   * event claims, `store` floors upload claims. A destination without a
-   * known price keeps the computed fee unchanged (pre-floor behavior).
+   * FLAT per-packet route prices for the publish/store destinations, as the
+   * payment peer announces them (kind:10032 `capabilities` — e.g.
+   * `{capability:'os.publish', address:'g.proxy.relay', price:'1000'}`) or as
+   * the terminating connector reports them from `GET /ilp/routes/price`.
+   *
+   * The connector gates every paid packet at the destination route's price: a
+   * balance-proof claim advancing the channel by less is rejected (F06). Since
+   * ADR 0020 (toon-client#452) a price is flat per handler, so `store` is the
+   * WHOLE upload fee rather than a floor under a per-byte computation — an
+   * upload of any size costs it. `publish` still floors {@link eventFee},
+   * which remains a caller-chosen flat figure.
+   *
+   * A destination without a known price prices its packets at 0 here and lets
+   * the connector be the one to refuse — this class never invents a rate.
    */
   routePrices?: { publish?: bigint; store?: bigint };
   /** Daemon control API port probed by the nonce guard. */
@@ -258,69 +261,19 @@ export function deriveRouteDestinations(anchor: string): {
 }
 
 // ---------------------------------------------------------------------------
-// FULFILL → Arweave txId (mirrors @toon-protocol/client blob-storage.ts,
-// whose extractor is not exported; uses the exported parseFulfillHttp)
+// FULFILL → Arweave txId
 // ---------------------------------------------------------------------------
 
-/** Arweave tx IDs are base64url-encoded 32-byte values (43 chars). */
-const ARWEAVE_TX_ID_REGEX = /^[A-Za-z0-9_-]{43}$/;
-
 /**
- * Decode the Arweave txId from a store-write FULFILL. The deployed payment
- * proxy returns the store's verbatim HTTP/1.1 response
- * (`{"accept":true,"txId":…}` body); legacy non-proxy providers return bare
- * `base64(utf8(txId))`.
+ * Decode the Arweave txId from a store-write answer.
  *
- * @throws {StandalonePublishError} when no valid txId can be extracted.
+ * Re-exported from `@toon-protocol/client` rather than reimplemented: this
+ * file used to carry its own copy because the client's extractor was thought
+ * not to be exported. It is (and always was), and now that the answer is a
+ * sealed response envelope rather than HTTP text there is exactly one shape
+ * to read — a second reader of it could only drift.
  */
-export function extractArweaveTxId(base64Data: string): string {
-  const http = parseFulfillHttp(base64Data);
-
-  if (!http.isHttp) {
-    const legacy = Buffer.from(base64Data, 'base64').toString('utf8');
-    if (!ARWEAVE_TX_ID_REGEX.test(legacy)) {
-      throw new StandalonePublishError(
-        `FULFILL data is not a valid Arweave tx ID: "${legacy}"`
-      );
-    }
-    return legacy;
-  }
-
-  if (http.status < 200 || http.status >= 300) {
-    throw new StandalonePublishError(
-      `git-object upload failed: store returned HTTP ${http.status}` +
-        (http.body ? ` - ${http.body}` : '')
-    );
-  }
-
-  let parsed: { accept?: boolean; txId?: unknown; data?: unknown; error?: unknown };
-  try {
-    parsed = JSON.parse(http.body) as typeof parsed;
-  } catch {
-    throw new StandalonePublishError(
-      `git-object upload response body was not valid JSON: "${http.body}"`
-    );
-  }
-
-  if (parsed.accept === false) {
-    const reason = typeof parsed.error === 'string' ? `: ${parsed.error}` : '';
-    throw new StandalonePublishError(
-      `git-object upload rejected by store (accept:false)${reason}`
-    );
-  }
-
-  if (typeof parsed.txId === 'string' && ARWEAVE_TX_ID_REGEX.test(parsed.txId)) {
-    return parsed.txId;
-  }
-  if (typeof parsed.data === 'string' && parsed.data.length > 0) {
-    const decoded = Buffer.from(parsed.data, 'base64').toString('utf8');
-    if (ARWEAVE_TX_ID_REGEX.test(decoded)) return decoded;
-  }
-
-  throw new StandalonePublishError(
-    `git-object upload response did not contain a valid Arweave tx ID: "${http.body}"`
-  );
-}
+export { extractArweaveTxId };
 
 // ---------------------------------------------------------------------------
 // Channel-resume introspection (#262)
@@ -401,7 +354,6 @@ export class StandalonePublisher implements Publisher {
   private readonly storeDestination: string | undefined;
   private readonly channelDestination: string | undefined;
   private readonly eventFee: bigint;
-  private readonly uploadFeePerByte: bigint;
   private readonly routePrices:
     | StandalonePublisherOptions['routePrices']
     | undefined;
@@ -453,7 +405,6 @@ export class StandalonePublisher implements Publisher {
     this.channelDestination = options.channelDestination;
 
     this.eventFee = options.eventFee ?? 1n;
-    this.uploadFeePerByte = options.uploadFeePerByte ?? 10n;
     this.routePrices = options.routePrices;
     this.daemonPort = options.daemonPort;
     this.skipDaemonCheck = options.skipDaemonCheck ?? false;
@@ -462,8 +413,7 @@ export class StandalonePublisher implements Publisher {
     this.channelMap = options.channelMap;
     this.channelAnchor = anchor;
     this.negotiationFallbacks = options.negotiationFallbacks;
-    this.warn =
-      options.warn ?? ((line) => process.stderr.write(`${line}\n`));
+    this.warn = options.warn ?? ((line) => process.stderr.write(`${line}\n`));
   }
 
   /** Hex Nostr pubkey of the embedded identity (available before start). */
@@ -605,7 +555,11 @@ export class StandalonePublisher implements Publisher {
     // Corruption check happens HERE, before any on-chain open (throws).
     const candidates = map.listFor(identity, anchor);
     const internals = channelInternals(this.client);
-    const resumed = await this.resumeRecordedChannel(map, candidates, internals);
+    const resumed = await this.resumeRecordedChannel(
+      map,
+      candidates,
+      internals
+    );
 
     // Idempotent — returns the (resumed or existing) channel for the peer if
     // one is tracked, else opens lazily on-chain.
@@ -942,20 +896,15 @@ export class StandalonePublisher implements Publisher {
   // ── Publisher ─────────────────────────────────────────────────────────────
 
   /**
-   * Fee rates for `planPush` estimation: the flat per-event fee and the
-   * per-byte upload rate this publisher pays (daemon `feePerEvent` and seed
-   * bid-rate conventions; override via options), with the announced route
-   * prices folded in so the ESTIMATE always equals the CLAIMS: the flat
-   * `eventFee` is returned pre-floored at the publish route price, and the
-   * store route price rides as `minUploadFee` (the per-upload floor —
-   * per-byte pricing can't fold a flat floor into the rate).
+   * Fee rates for `planPush` estimation, both flat per packet (ADR 0020),
+   * with the announced route prices folded in so the ESTIMATE always equals
+   * the CLAIMS: `eventFee` is returned pre-floored at the publish route price,
+   * and `uploadFee` IS the store route price.
    */
   getFeeRates(): Promise<FeeRates> {
-    const minUploadFee = this.routePrices?.store;
     return Promise.resolve({
-      uploadFeePerByte: this.uploadFeePerByte,
+      uploadFee: this.uploadFee(),
       eventFee: this.effectiveEventFee(),
-      ...(minUploadFee !== undefined ? { minUploadFee } : {}),
     });
   }
 
@@ -969,22 +918,21 @@ export class StandalonePublisher implements Publisher {
   }
 
   /**
-   * The per-upload claim: `bytes × uploadFeePerByte`, floored at the store
-   * route's announced price (the connector rejects a claim below it — F06).
+   * The per-upload claim: the store route's flat price, whatever the object's
+   * size. Byte-proportional pricing has no successor (ADR 0020) — the route
+   * table is the price list — and the connector charges this figure whether
+   * the body is 100 bytes or 100 KB.
    */
-  private uploadFee(bytes: number): bigint {
-    return flooredUploadFee(
-      bytes,
-      this.uploadFeePerByte,
-      this.routePrices?.store
-    );
+  private uploadFee(): bigint {
+    return this.routePrices?.store ?? 0n;
   }
 
   /**
    * Upload one git object as a kind:5094 store write (Git-SHA/Git-Type/Repo
    * tagged — the proven seed-pipeline shape), signing one balance-proof claim
-   * for `body.length × uploadFeePerByte`, floored at the store route's
-   * announced price ({@link StandalonePublisherOptions.routePrices}).
+   * for the store route's flat price
+   * ({@link StandalonePublisherOptions.routePrices}) — ADR 0020 prices a
+   * packet per handler, not per byte.
    *
    * #368: a blob's `Content-Type` is derived from its path extension (else
    * octet-stream) and sent in the `output` tag, which the store forwards onto
@@ -1006,7 +954,7 @@ export class StandalonePublisher implements Publisher {
         ? contentTypeForPath(upload.path)
         : DEFAULT_CONTENT_TYPE;
 
-    const fee = this.uploadFee(upload.body.length);
+    const fee = this.uploadFee();
     const event = this.client.signEvent({
       kind: 5094,
       content: '',
@@ -1034,12 +982,12 @@ export class StandalonePublisher implements Publisher {
         `git-object upload rejected (${upload.sha}): ${result.error ?? 'store rejected the write'}`
       );
     }
-    if (!result.data) {
+    if (!result.response) {
       throw new StandalonePublishError(
-        `git-object upload FULFILL carried no data (${upload.sha}); expected the Arweave tx ID`
+        `git-object upload FULFILL carried no sealed response (${upload.sha}); expected the Arweave tx ID`
       );
     }
-    return { txId: extractArweaveTxId(result.data), feePaid: fee };
+    return { txId: extractArweaveTxId(result.response), feePaid: fee };
   }
 
   /**
@@ -1048,8 +996,7 @@ export class StandalonePublisher implements Publisher {
    * tags (and an optional `Repo` provenance tag), NOT the Git-SHA/Git-Type
    * tags. Without those the store keeps the bytes verbatim instead of
    * re-deriving a git envelope, which is exactly what the ar.io path manifest
-   * needs. One balance-proof claim for `body.length × uploadFeePerByte`,
-   * floored at the store route's announced price.
+   * needs. One balance-proof claim for the store route's flat price.
    */
   async uploadBlob(upload: BlobUpload): Promise<UploadReceipt> {
     if (upload.body.length > MAX_OBJECT_SIZE) {
@@ -1060,7 +1007,7 @@ export class StandalonePublisher implements Publisher {
     await this.start();
     const channelId = this.requireChannel();
 
-    const fee = this.uploadFee(upload.body.length);
+    const fee = this.uploadFee();
     const event = this.client.signEvent({
       kind: 5094,
       content: '',
@@ -1085,12 +1032,12 @@ export class StandalonePublisher implements Publisher {
         `blob upload rejected: ${result.error ?? 'store rejected the write'}`
       );
     }
-    if (!result.data) {
+    if (!result.response) {
       throw new StandalonePublishError(
-        'blob upload FULFILL carried no data; expected the Arweave tx ID'
+        'blob upload FULFILL carried no sealed response; expected the Arweave tx ID'
       );
     }
-    return { txId: extractArweaveTxId(result.data), feePaid: fee };
+    return { txId: extractArweaveTxId(result.response), feePaid: fee };
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.21.1
-        version: 0.21.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.22.0
+        version: 0.22.0(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^3.1.2
         version: 3.1.3(typescript@5.9.3)
@@ -156,8 +156,8 @@ importers:
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)
       '@toon-protocol/client':
-        specifier: ^0.21.1
-        version: 0.21.1(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.22.0
+        version: 0.22.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^1.6.0
         version: 1.6.0(@toon-protocol/connector@3.41.0)(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
@@ -8582,10 +8582,77 @@ packages:
       - uploadthing
       - utf-8-validate
       - zod
+    dev: false
 
-  /@toon-protocol/client@0.21.1(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-e3jD617/sfe3pJDwv8DGBfC2ZnP6dv3fM6UstNhNO9t6P7DmwMWT7u4KB68+1eE0JCxQBO6N5G2cF+ZUa766Gg==}
+  /@toon-protocol/client@0.22.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-PE6zfDBCMGZpNZpdZXC4RkVapkxtgjz68Np2ugItlE5pFl0SaL+3W4E/SoVweXszE4Mgpih8RkChYA6aaIt7Bw==}
     dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.2.0
+      '@noble/ed25519': 2.3.0
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      '@toon-protocol/core': 3.1.3(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
+      '@toon-protocol/sdk': 3.1.3(@types/react@19.2.17)(mina-signer@3.1.0)(react@19.2.8)(typescript@5.9.3)
+      nostr-tools: 2.24.1(typescript@5.9.3)
+      viem: 2.55.5(typescript@5.9.3)(zod@3.25.76)
+    optionalDependencies:
+      '@solana/web3.js': 1.98.4(typescript@5.9.3)
+      '@toon-protocol/mina-zkapp': 0.1.1
+      mina-signer: 3.1.0
+      o1js: 2.14.0
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@toon-protocol/connector'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - preact-render-to-string
+      - react
+      - react-native
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    dev: true
+
+  /@toon-protocol/client@0.22.0(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-PE6zfDBCMGZpNZpdZXC4RkVapkxtgjz68Np2ugItlE5pFl0SaL+3W4E/SoVweXszE4Mgpih8RkChYA6aaIt7Bw==}
+    dependencies:
+      '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0
       '@noble/ed25519': 2.3.0
       '@noble/hashes': 1.8.0


### PR DESCRIPTION
Bumps both `@toon-protocol/client` pins — `packages/rig/package.json` and `packages/rig-web/package.json` — from `^0.21.1` to `^0.22.0`, and fixes the repo onto the new surface.

This repo is a *second copy* of rig. The copy in the toon-client monorepo consumes the client via `workspace:^` and already took these changes, so this PR **matches that implementation rather than inventing a second one** — a divergence between two copies of rig is the trap here. Reference: toon-client#457 (for #450) and toon-client#459 (for #452). All seven source files applied from those diffs cleanly with `git apply --3way`.

## What broke, and what replaced it

**1. The store's answer is a sealed envelope, not HTTP text.**
`parseFulfillHttp` is deleted from the client. A paid write is now an OER `EnvelopeRequest` (ADR 0018) inside a gift wrap addressed to the terminating connector, with the answer opened under the same secret. `PublishEventResult.data` becomes `.response`, the opened envelope.

`extractArweaveTxId` is no longer reimplemented in `standalone-publisher.ts` — it is **re-exported from `@toon-protocol/client`**. This file only ever carried a copy because the client's extractor was thought not to be exported. It is (and always was), and now that there is exactly one answer shape to read, a second reader could only drift.

**2. A price is flat per route, and the route is asked for it.**
ADR 0020 removes byte-proportional pricing from the protocol: one handler, one price. `FeeRates.uploadFeePerByte` and `FeeRates.minUploadFee` collapse into one flat `FeeRates.uploadFee`; `flooredUploadFee()` — the `max(bytes × rate, floor)` helper those two fields existed to feed — goes with them. The already-present `routePrices.store` now carries the *whole* upload fee rather than a floor under a per-byte computation, so `getFeeRates()` still equals the claims actually signed.

## The `uploadFeePerByte` decision: removed, not deprecated

`StandalonePublisherOptions.uploadFeePerByte` was a public constructor option, so removing it is a breaking change to *this* package. It is **removed** rather than kept accepted-but-ignored.

A per-byte fee option that cannot affect what any packet costs is a lie told to every caller who sets it — and worse than inert, it would silently misprice `planPush` estimates against the claims actually signed, which is exactly the class of bug the flat price exists to make impossible. There is also no successor to migrate onto: byte-proportional pricing is gone from the protocol, not relocated.

**Versioning:** `@toon-protocol/rig` is at `2.14.0` — past 1.0, so removing exported API requires a **major** bump. The changeset marks it `major`, matching the bump the monorepo gave rig for the same change.

## Verification

`pnpm` (via `pnpm-lock.yaml`; no `package-lock.json`). Baseline measured on the **unmodified** repo first, so pre-existing failures are not mistaken for new ones.

| Check | Before | After |
|---|---|---|
| `pnpm build` | pass | pass |
| `pnpm typecheck` | pass (0 errors) | pass (0 errors) |
| `pnpm lint` | pass — 0 errors, 220 warnings | pass — 0 errors, 220 warnings |
| CI correctness gate | pass | pass (`0e/220w` vs frozen baseline) |
| `packages/rig` tests | 909 passed, 3 skipped (42 files) | **909 passed, 3 skipped (42 files)** |
| `packages/rig-web` tests | 348 passed, 12 skipped (30 files) | **348 passed, 12 skipped (30 files)** |
| `pnpm format:check` | **fail — 129 files** (pre-existing) | fail — **117 files** |

`format:check` fails on `main` and is not in the CI gate; it is not introduced or worsened here. It *improves* by 12 files, because the applied hunks carry the monorepo's formatting. Offender-list diff confirms **zero newly non-compliant files**.

**No test was weakened, skipped or deleted.** 14 test cases asserted per-byte fee behaviour; all 14 are rewritten onto the flat-price shape (`+14 / -14` on `it(`/`test(` — net zero), which is why the totals are unchanged.

## One thing deliberately left alone

`packages/rig-web/tests/e2e/seed/**` still hand-computes `bytes * 10n` claim amounts (6 files) and reads the removed `result.data`. It is **already excluded from typecheck** and documented in `packages/rig-web/tsconfig.json` as a dead harness from the pre-extraction monorepo layout — cross-repo `../../../../../sdk|client` imports that no longer resolve, plus an uninstalled `nostr-tools`. **rig#28** tracks restore-or-delete as a human-decided follow-up. It does not build, run or gate anything, so repricing it here would be guessing at a decision that issue exists to make.

Closes nothing; opened for review, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)