### PR TITLE
feat(rig): the official Rust edge is the default uplink (connector #616)

### DIFF
--- a/.changeset/official-edge-default.md
+++ b/.changeset/official-edge-default.md
@@ -1,0 +1,20 @@
+---
+'@toon-protocol/rig': minor
+---
+
+The official Rust edge is rig's default uplink.
+
+With no explicit entry (`rig entry <url>` / `rig entry sandbox` /
+`TOON_CLIENT_*` env), paid writes now go to the official TOON relay
+implementation — the Rust connector at
+`https://proxy.devnet.toonprotocol.dev/rust/ilp`, route `g.toon.relay`
+(connector #616). A live announce no longer places the uplink (it still
+informs the destination anchor, routes, prices and bootstrap peers), and a
+price floor from one fleet's announce no longer binds a write that targets
+another fleet's edge.
+
+Requires `@toon-protocol/client` ^0.24.0 (bumped here): the official edge
+never announces (ADR 0022), so the channel bootstrap comes from the
+client's new announce-less path — the edge's x402 greeting carries the
+channel-opening facts (connector #617) and the client synthesizes the
+negotiation from them.

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.22.0",
+    "@toon-protocol/client": "^0.24.0",
     "@toon-protocol/core": "^3.1.2",
     "nostr-tools": "^2.20.0"
   },

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -20,6 +20,8 @@ import {
 import { MinaZkAppStore } from '../standalone/mina-zkapp-store.js';
 import {
   MissingUplinkError,
+  OFFICIAL_PROXY_URL,
+  OFFICIAL_PUBLISH_DESTINATION,
   buildMinaAutoDeploy,
   resolveNetworkTopology,
   type ClientConfigFile,
@@ -104,20 +106,25 @@ function inputs(
 // ---------------------------------------------------------------------------
 
 describe('resolveNetworkTopology — uplink', () => {
-  it('derives the proxy uplink from the announce httpEndpoint (no config)', async () => {
+  // The cutover (connector #616): the Rust connector is the official TOON
+  // relay implementation, so with no EXPLICIT entry the uplink is the
+  // official edge — even when a live announce names another fleet's
+  // endpoints. The announce keeps informing the destination anchor, routes,
+  // prices and bootstrap peers; it just no longer places the uplink.
+  it('defaults the uplink to the official edge, announce or not', async () => {
     const topology = await resolveNetworkTopology(inputs());
-    expect(topology.proxyUrl).toBe('https://proxy.devnet.toonprotocol.dev');
+    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
     expect(topology.btpUrl).toBeUndefined();
   });
 
-  it('explicit env proxy beats the announce', async () => {
+  it('explicit env proxy beats the official default', async () => {
     const topology = await resolveNetworkTopology(
       inputs({ env: { TOON_CLIENT_PROXY_URL: 'https://my-proxy.example' } })
     );
     expect(topology.proxyUrl).toBe('https://my-proxy.example');
   });
 
-  it('explicit config-file btpUrl beats the announce', async () => {
+  it('explicit config-file btpUrl beats the official default', async () => {
     const topology = await resolveNetworkTopology(
       inputs({ file: { btpUrl: 'wss://my-btp.example:443' } })
     );
@@ -125,27 +132,19 @@ describe('resolveNetworkTopology — uplink', () => {
     expect(topology.proxyUrl).toBeUndefined();
   });
 
-  it('announce btpEndpoint is used when it has no httpEndpoint', async () => {
+  it('an announce without an httpEndpoint still does not place the uplink', async () => {
     const topology = await resolveNetworkTopology(
       inputs({ announce: apexAnnounce({ httpEndpoint: undefined }) })
     );
-    expect(topology.proxyUrl).toBeUndefined();
-    expect(topology.btpUrl).toBe('wss://proxy.devnet.toonprotocol.dev:443');
+    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+    expect(topology.btpUrl).toBeUndefined();
   });
 
-  it('falls back to the genesis seed btpEndpoint without an announce', async () => {
+  it('needs neither an announce nor a genesis seed for an uplink', async () => {
     const topology = await resolveNetworkTopology(
-      inputs({ announce: undefined })
+      inputs({ announce: undefined, genesisSeed: undefined })
     );
-    expect(topology.btpUrl).toBe(GENESIS.btpEndpoint);
-  });
-
-  it('throws MissingUplinkError when no source yields an uplink', async () => {
-    await expect(
-      resolveNetworkTopology(
-        inputs({ announce: undefined, genesisSeed: undefined })
-      )
-    ).rejects.toThrow(MissingUplinkError);
+    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
   });
 });
 
@@ -190,8 +189,9 @@ describe('resolveNetworkTopology — destination and routes', () => {
       inputs({ announce: undefined })
     );
     expect(topology.destination).toBe('g.proxy');
-    // No routes derivable — the publisher's anchor convention takes over.
-    expect(topology.publishDestination).toBeUndefined();
+    // The uplink defaulted to the official edge, so the publish route is
+    // that edge's own (connector #616); store has no official default yet.
+    expect(topology.publishDestination).toBe(OFFICIAL_PUBLISH_DESTINATION);
     expect(topology.storeDestination).toBeUndefined();
   });
 
@@ -767,11 +767,14 @@ describe('resolveNetworkTopology — route prices', () => {
         env: { TOON_CLIENT_DESTINATION: 'g.proxy.relay.store' },
       })
     );
-    // No announced routes: the publisher's `<base>.relay.store` derivation
-    // yields g.proxy.relay / g.proxy.store — the priced routes.
-    expect(topology.publishDestination).toBeUndefined();
+    // The uplink defaulted to the official edge, so the effective publish
+    // destination is g.toon.relay — which this announce's capabilities do
+    // NOT price. A floor from one fleet's announce must not bind a write
+    // that targets another fleet's edge; only the still-derived store
+    // route keeps its announced floor.
+    expect(topology.publishDestination).toBe(OFFICIAL_PUBLISH_DESTINATION);
     expect(topology.storeDestination).toBeUndefined();
-    expect(topology.routePrices).toEqual({ publish: '1000', store: '1500' });
+    expect(topology.routePrices).toEqual({ store: '1500' });
   });
 });
 

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -145,6 +145,22 @@ export interface ClientConfigFile {
 }
 
 /** An identity was resolved, but there is no way to send paid writes. */
+/**
+ * The official TOON relay implementation's client edge — the Rust connector
+ * on the devnet apex (connector #616: the parallel-fleet comparison
+ * concluded and the Rust fleet serves the protocol's own `g.toon`
+ * namespace). This is rig's DEFAULT uplink: paid writes go here unless an
+ * entry is explicitly configured (`rig entry <url>` / `rig entry sandbox` /
+ * the TOON_CLIENT_* env overrides). The channel bootstrap needs no
+ * announce: the edge's x402 greeting carries the channel-opening facts
+ * (connector #617), which the embedded client synthesizes a negotiation
+ * from.
+ */
+export const OFFICIAL_PROXY_URL =
+  'https://proxy.devnet.toonprotocol.dev/rust/ilp';
+/** The official relay-write route on that edge. */
+export const OFFICIAL_PUBLISH_DESTINATION = 'g.toon.relay';
+
 export class MissingUplinkError extends Error {
   constructor(configPath: string, relayUrl: string | undefined) {
     const discovered = relayUrl
@@ -444,21 +460,19 @@ export async function resolveNetworkTopology(
     ...(file.tokenNetworks ? { tokenNetworks: file.tokenNetworks } : {}),
   };
 
-  // ── Uplink: explicit > announce (http > btp) > genesis seed ──────────────
+  // ── Uplink: explicit > THE OFFICIAL EDGE ─────────────────────────────────
+  // The cutover (connector #616): the Rust connector is the official TOON
+  // relay implementation, so with no explicit entry the uplink IS the
+  // official edge — the live announce and the genesis seed no longer place
+  // the uplink (they still inform the destination anchor, routes, prices
+  // and bootstrap peers below). Opting onto another fleet is what
+  // `rig entry <url>` / `rig entry sandbox` and the TOON_CLIENT_* env
+  // overrides are for, and those are all EXPLICIT. `MissingUplinkError`
+  // can no longer fire from here — an uplink always resolves.
   let proxyUrl = explicitProxyUrl;
   let btpUrl = explicitBtpUrl;
   if (!proxyUrl && !btpUrl) {
-    if (announce?.info.httpEndpoint) {
-      proxyUrl = proxyBaseOf(announce.info.httpEndpoint);
-    } else if (announce?.info.btpEndpoint) {
-      btpUrl = announce.info.btpEndpoint;
-    } else if (genesisSeed?.btpEndpoint) {
-      btpUrl = genesisSeed.btpEndpoint;
-    } else if (inputs.requireUplink !== false) {
-      // Free reads (`rig balance`, #263) tolerate a missing uplink; paid
-      // commands fail here, after every source has been tried.
-      throw new MissingUplinkError(configPath, relayUrl);
-    }
+    proxyUrl = OFFICIAL_PROXY_URL;
   }
 
   // ── Destination anchor + publish/store routes ────────────────────────────
@@ -471,7 +485,12 @@ export async function resolveNetworkTopology(
     announce?.info.ilpAddress ??
     genesisSeed?.ilpAddress ??
     'g.proxy';
-  const publishDestination = explicitPublish ?? announce?.routes?.publish;
+  const publishDestination =
+    explicitPublish ??
+    announce?.routes?.publish ??
+    (proxyUrl === OFFICIAL_PROXY_URL
+      ? OFFICIAL_PUBLISH_DESTINATION
+      : undefined);
   const storeDestination = explicitStore ?? announce?.routes?.store;
 
   // ── Route-price floors ───────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.22.0
-        version: 0.22.0(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.24.0
+        version: 0.24.0(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^3.1.2
         version: 3.1.3(typescript@5.9.3)
@@ -8649,8 +8649,8 @@ packages:
       - zod
     dev: true
 
-  /@toon-protocol/client@0.22.0(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-PE6zfDBCMGZpNZpdZXC4RkVapkxtgjz68Np2ugItlE5pFl0SaL+3W4E/SoVweXszE4Mgpih8RkChYA6aaIt7Bw==}
+  /@toon-protocol/client@0.24.0(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-F8nqAbdU0JUUf9CrQSsYVFx5g3AOAKh2VAfQf1Zisem2u1vib9y9GdwmaysSTJZXbSOHj+jqmb4wOa1hrm/t4A==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0


### PR DESCRIPTION
Port of toon-client#468's rig half to the repo that actually publishes `@toon-protocol/rig`, plus the `@toon-protocol/client` bump to ^0.24.0 (npm-published; brings the announce-less x402-greeting channel bootstrap, connector #617/#618 — required because the official edge never announces, ADR 0022).

- Default uplink: `https://proxy.devnet.toonprotocol.dev/rust/ilp`, publish route `g.toon.relay`; explicit entries (`rig entry`, `TOON_CLIENT_*`) still win
- A live announce no longer places the uplink; still informs anchor/routes/prices/bootstrap peers; a foreign fleet's price floor no longer binds writes to this edge
- 908/908 tests green on client 0.24.0 (+3 skipped)

The live devnet greeting already serves the channel-opening facts this path consumes (verified off-box after connector#618's deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LycZDzED7CnvjK7aYn2Nd1