### PR TITLE
chore(rig): consume @toon-protocol/client 0.25.0 (Solana greeting-bootstrap)

### DIFF
--- a/.changeset/rig-client-0-25-0-solana-bootstrap.md
+++ b/.changeset/rig-client-0-25-0-solana-bootstrap.md
@@ -1,0 +1,23 @@
+---
+'@toon-protocol/rig': minor
+---
+
+Consume `@toon-protocol/client@^0.25.0`, so a published rig can do the Solana greeting-bootstrap.
+
+`^0.24.0` on a 0.x version resolves to `>=0.24.0 <0.25.0`, so rig could not pick 0.25.0 up
+on its own — the devnet e2e had to run rig from toon-client workspace source. This bump makes
+the published artifact carry the real thing.
+
+What rig gains from client 0.25.0:
+
+- **Solana greeting-bootstrap** (toon-client#470) — a wallet holding only Solana assets can
+  open a payment channel and pay through a settling connector, with no prior EVM funding and
+  no `kind:10032` announce required.
+- **Solana open-path fixes** (toon-client#476) — the channel is funded at open rather than
+  left at zero; the connector greeting's `programId` is honoured instead of a hardcoded
+  default; an existing under-collateralized channel is topped up instead of being reused as
+  is; and RPC failures are discriminated from genuine "no such channel" answers so a flaky
+  endpoint no longer looks like a missing channel.
+
+`@toon-protocol/rig-web` is `private: true` and is deployed rather than published, so it is
+unaffected by this release.

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.24.0",
+    "@toon-protocol/client": "^0.25.0",
     "@toon-protocol/core": "^3.1.2",
     "nostr-tools": "^2.20.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.24.0
-        version: 0.24.0(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.25.0
+        version: 0.25.0(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^3.1.2
         version: 3.1.3(typescript@5.9.3)
@@ -8649,8 +8649,8 @@ packages:
       - zod
     dev: true
 
-  /@toon-protocol/client@0.24.0(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-F8nqAbdU0JUUf9CrQSsYVFx5g3AOAKh2VAfQf1Zisem2u1vib9y9GdwmaysSTJZXbSOHj+jqmb4wOa1hrm/t4A==}
+  /@toon-protocol/client@0.25.0(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-j/2UDz3MgNq8P4vZ573z5FBHx7ilpVZJQDq6teNTJvd4FJM+roye0N7IQHuhpmL/ARKnQxCGz8B+WiDutXeFDg==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0


### PR DESCRIPTION
## Why

`packages/rig` pinned `@toon-protocol/client: ^0.24.0`. On a 0.x version that caret means `>=0.24.0 <0.25.0`, so rig could **not** pick up `@toon-protocol/client@0.25.0` on its own — no published rig can do the Solana bootstrap, and the devnet e2e had to run rig from toon-client workspace source. This is the explicit bump + release that fixes that.

## What client 0.25.0 brings rig

- **Solana greeting-bootstrap** (toon-client#470) — a wallet holding only Solana assets can open a payment channel and pay through a settling connector, with no prior EVM funding and no `kind:10032` announce.
- **Solana open-path fixes** (toon-client#476) — fund the channel at open (rather than opening it at zero), honour the connector greeting's `programId` instead of a hardcoded default, top up an existing under-collateralized channel instead of reusing it as is, and discriminate RPC failures from a genuine "no such channel" answer.

## Changes

- `packages/rig/package.json`: `@toon-protocol/client` `^0.24.0` → `^0.25.0`
- `pnpm-lock.yaml`: regenerated with pnpm 8.15.9 (matches `packageManager` / CI)
- changeset: **minor** for `@toon-protocol/rig` (3.2.0 → 3.3.0)

`packages/rig-web` is `private: true` (deployed, not published) and is untouched — it stays on its own client range.

## Verification (local, against the real published client)

- Resolved `@toon-protocol/client` in `packages/rig/node_modules` is **0.25.0**
- Its `dist/index.js` contains all four new-code markers: `parseChainSettlementEntry`, `topUpExistingChannel`, `MIN_LAMPORTS_FOR_DEPOSIT`, `SolanaRpcError`
- `.sandcastle/gate/*.test.ts`: 17/17 pass
- `.sandcastle/gate/correctness.ts`: **PASSED** — eslint 0e/220w, typecheck 0e (exactly the frozen baseline)
- `pnpm -r build`: green
- `pnpm -r test`: `@toon-protocol/rig` 908 passed / 3 skipped; `@toon-protocol/rig-web` 348 passed / 12 skipped

The published artifact gets smoke-tested automatically by `smoke-published.yml`, which runs on Release completion.