### PR TITLE
chore(rig-web): bump @toon-protocol/client to ^0.25.0

### DIFF
--- a/packages/rig-web/package.json
+++ b/packages/rig-web/package.json
@@ -37,7 +37,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
-    "@toon-protocol/client": "^0.22.0",
+    "@toon-protocol/client": "^0.25.0",
     "@toon-protocol/core": "^1.6.0",
     "@toon-protocol/relay": "^1.3.1",
     "@toon-protocol/rig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)
       '@toon-protocol/client':
-        specifier: ^0.22.0
-        version: 0.22.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.25.0
+        version: 0.25.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^1.6.0
         version: 1.6.0(@toon-protocol/connector@3.41.0)(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
@@ -8584,8 +8584,8 @@ packages:
       - zod
     dev: false
 
-  /@toon-protocol/client@0.22.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-PE6zfDBCMGZpNZpdZXC4RkVapkxtgjz68Np2ugItlE5pFl0SaL+3W4E/SoVweXszE4Mgpih8RkChYA6aaIt7Bw==}
+  /@toon-protocol/client@0.25.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-j/2UDz3MgNq8P4vZ573z5FBHx7ilpVZJQDq6teNTJvd4FJM+roye0N7IQHuhpmL/ARKnQxCGz8B+WiDutXeFDg==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0


### PR DESCRIPTION
Closes #48.

## What #48 asked, and the answer

**Does rig-web actually exercise the channel-open / payment path? No.**

The dependency is a **devDependency used only by the E2E seed harness** (`tests/e2e/seed/`), which drives `ToonClient` in Node to seed a devnet with NIP-34 git events so the browser tests have data to read. That harness does open channels and sign balance proofs — but it is EVM/Anvil-based.

The **deployed browser app does not**:

- `src/`'s only `@toon-protocol` imports are `/arweave` and `/views` — zero `@toon-protocol/client`.
- No `openChannel` / `ChannelManager` / `negotiateFromGreeting` / claim usage anywhere in `src/`.
- Reads go over its own minimal WebSocket relay client (`src/web/relay-client.ts`) — free NIP-01 reads.
- The built `dist/` bundle contains no `ToonClient` / `openChannel` / `ChannelManager` markers.

So the premise that "the deployed web UI lacks the Solana work" is true only in the trivial sense: the web UI has no payment path at all, and never could serve or fail Solana-only users. **This bump is hygiene, not a user-facing fix, and the urgency is low.**

## What it does fix

`packages/rig` moved to `^0.25.0` in #46 while rig-web stayed on `^0.22.0`, so the workspace resolved **two copies** of the client. This collapses that to one — both packages now resolve 0.25.0.

(A transitive `0.21.1` remains under `@toon-protocol/views`'s own tree — an upstream pin inside the published `views@0.20.5`, out of scope here, and tree-shaken out of the browser bundle.)

## Release / deploy

rig-web is `private: true` and `.changeset/config.json` ignores it — deployed, not published, so **no changeset and no npm release**. Merging triggers `deploy-rig-web.yml` automatically (it watches `packages/rig-web/**`).

## Gate

| check | result | baseline |
|---|---|---|
| `pnpm -r build` | green | — |
| typecheck | **0 errors** | 0 errors |
| eslint | **0 errors / 220 warnings** | 0 / 220 |
| `.sandcastle/gate/correctness.ts` | **PASSED** (no new violations) | — |
| gate unit tests | 17/17 | — |
| tests | 908 (rig) + 348 (rig-web) passing | — |

The 0.22 → 0.25 jump surfaced **no API breakage** — nothing needed fixing, and no `any`/`ts-ignore` was used.

`pnpm format:check` fails on 117 files, but that is pre-existing (identical on clean `main`, and its glob `packages/*/src/**/*.{ts,tsx}` cannot cover the two files changed here). CI does not run it.

Lockfile updated with pnpm 8.15.9 per `packageManager`.