### PR TITLE
test(rig): repoint the store announce fixture at proxy.ario.devnet

### DIFF
--- a/packages/rig/src/standalone/network-bootstrap.test.ts
+++ b/packages/rig/src/standalone/network-bootstrap.test.ts
@@ -280,8 +280,12 @@ describe('pickPaymentPeer', () => {
     {
       ...APEX_CONTENT,
       ilpAddress: 'g.proxy.store',
-      httpEndpoint: 'https://proxy.store.devnet.toonprotocol.dev/ilp',
-      btpEndpoint: 'wss://proxy.store.devnet.toonprotocol.dev:443',
+      // `proxy.ario`, not `proxy.store` — the devnet store box's paid edge was
+      // renamed on 2026-08-05 (connector#774) and the old name is a deprecated
+      // alias slated for removal. The fixture asserts routing preference, not
+      // the hostname, but a fixture is the first thing anyone copies.
+      httpEndpoint: 'https://proxy.ario.devnet.toonprotocol.dev/ilp',
+      btpEndpoint: 'wss://proxy.ario.devnet.toonprotocol.dev:443',
       supportedChains: ['evm:31337'],
       settlementAddresses: { 'evm:31337': '0x1f4E' },
     },


### PR DESCRIPTION
`pickPaymentPeer`'s store fixture in `packages/rig/src/standalone/network-bootstrap.test.ts` advertised `proxy.store.devnet.toonprotocol.dev`.

That host was renamed to `proxy.ario.devnet.toonprotocol.dev` on 2026-08-05 (connector#774) to match the `g.toon.ario` prefix it serves. The old name survives only as a deprecated alias — same certificate, same upstream — and is slated for removal.

The test asserts routing preference (publish edge beats store edge; genesis seed beats both), not hostnames, so its meaning is unchanged. It is worth changing anyway: a fixture is the first thing anyone copies when writing the next announce-shaped test.

This repo is the canonical npm publisher for `@toon-protocol/rig`, so it gets the change in its own right rather than inheriting it — toon-client#512 carries the identical edit to its copy of the file.

## Gate

`pnpm --filter @toon-protocol/rig test` — 960 passed, 3 skipped.

Not caused by this change, both verified against a clean `origin/main`: the repo-wide `format:check` failure (127 files) and `rig-web`'s 3 failing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)