### PR TITLE
ci: add CI OK aggregate status job (toon-meta#279)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,47 @@ jobs:
           end=$(date +%s)
           export GATE_WALL_CLOCK_SECONDS=$((end - ${{ steps.gate_start.outputs.start }}))
           npx tsx .sandcastle/gate/regression.ts
+
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    needs: [changeset, build]
+    if: always()
+    steps:
+      # Fleet-wide aggregate required check per toon-meta#279: this single job
+      # is the repo's one required status. A skipped or cancelled gating job
+      # must never read as a pass, so each needed result is checked explicitly.
+      # `changeset` is skipped BY DESIGN on push events only (its `if:` gates
+      # it to pull_request); on PRs it must actually succeed.
+      - name: Verify all gating jobs succeeded
+        run: |
+          echo "event:     ${{ github.event_name }}"
+          echo "changeset: ${{ needs.changeset.result }}"
+          echo "build:     ${{ needs.build.result }}"
+
+          ok=true
+
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "::error::build did not succeed (result: ${{ needs.build.result }})"
+            ok=false
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # On PRs the changeset check always runs; skipped/cancelled/failure all fail.
+            if [ "${{ needs.changeset.result }}" != "success" ]; then
+              echo "::error::changeset did not succeed on a pull_request event (result: ${{ needs.changeset.result }})"
+              ok=false
+            fi
+          else
+            # On push events 'skipped' is the expected legitimate outcome ('success' also fine).
+            case "${{ needs.changeset.result }}" in
+              success|skipped) ;;
+              *)
+                echo "::error::changeset failed on a ${{ github.event_name }} event (result: ${{ needs.changeset.result }})"
+                ok=false
+                ;;
+            esac
+          fi
+
+          [ "$ok" = "true" ] || exit 1
+          echo "All gating jobs green."


### PR DESCRIPTION
## What

Appends a single aggregate job `ci-ok` (check context: **CI OK**) to `.github/workflows/ci.yml`. It `needs: [changeset, build]` and runs with `if: always()`, so it always reports — and its result is meant to become the repo's **single required check** (branch-protection repoint is done by the orchestrator, not this PR).

## Why

With per-job required checks, a skipped or cancelled gating job can read as a pass. The aggregate job closes that hole by inspecting each needed job's result explicitly:

- `build` must be `success` — anything else fails.
- `changeset` on `pull_request` events must be `success` — skipped/cancelled/failure all fail.
- `changeset` on `push` events: `skipped` is the expected, by-design outcome (its `if:` gates it to PRs); `success` is also accepted; any failing result fails.

The step prints each needed job's result plus `github.event_name` for auditability. No existing jobs were modified; no other files touched.

Part of toon-protocol/toon-meta#270
Part of toon-protocol/toon-meta#279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
