### PR TITLE
chore(deps): @toon-protocol/client ^0.29.0, @toon-protocol/core ^3.2.0

### DIFF
--- a/.changeset/bump-toon-deps.md
+++ b/.changeset/bump-toon-deps.md
@@ -1,0 +1,17 @@
+---
+'@toon-protocol/rig': patch
+---
+
+chore(deps): `@toon-protocol/client` `^0.29.0`, `@toon-protocol/core` `^3.2.0`
+
+Both bumps are required for the factory-job proof to reach `PROOF COMPLETE` against live
+devnet, and both were verified by a witnessed run rather than by the gate alone (#59, run 8).
+
+- `client ^0.29.0` — the previous `^0.26.x` range predates toon-client#503, so a client bound
+  under the literal BTP registry key `"client"` and its PREPARE `F02`d at the Rust edge. A
+  caret range on a `0.x` does not cross minors, so `pnpm install` never picked this up on its
+  own.
+- `core ^3.2.0` — carries the corrected devnet genesis peer seed (toon-protocol/toon#155). The
+  3.1.x seed pinned the retired TypeScript connector's nostr key, and `ToonClient`'s bootstrap
+  filters kind:10032 by `authors`, so a client got `EOSE, found 0 events` and could not open a
+  channel at all.

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.26.0",
-    "@toon-protocol/core": "^3.1.2",
+    "@toon-protocol/client": "^0.29.0",
+    "@toon-protocol/core": "^3.2.0",
     "nostr-tools": "^2.20.0"
   },
   "optionalDependencies": {

--- a/packages/rig/src/standalone/network-bootstrap.test.ts
+++ b/packages/rig/src/standalone/network-bootstrap.test.ts
@@ -280,8 +280,12 @@ describe('pickPaymentPeer', () => {
     {
       ...APEX_CONTENT,
       ilpAddress: 'g.proxy.store',
-      httpEndpoint: 'https://proxy.store.devnet.toonprotocol.dev/ilp',
-      btpEndpoint: 'wss://proxy.store.devnet.toonprotocol.dev:443',
+      // `proxy.ario`, not `proxy.store` — the devnet store box's paid edge was
+      // renamed on 2026-08-05 (connector#774) and the old name is a deprecated
+      // alias slated for removal. The fixture asserts routing preference, not
+      // the hostname, but a fixture is the first thing anyone copies.
+      httpEndpoint: 'https://proxy.ario.devnet.toonprotocol.dev/ilp',
+      btpEndpoint: 'wss://proxy.ario.devnet.toonprotocol.dev:443',
       supportedChains: ['evm:31337'],
       settlementAddresses: { 'evm:31337': '0x1f4E' },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,11 +51,11 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.26.0
-        version: 0.26.0(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.29.0
+        version: 0.29.0(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
-        specifier: ^3.1.2
-        version: 3.1.3(typescript@5.9.3)
+        specifier: ^3.2.0
+        version: 3.2.0(typescript@5.9.3)
       nostr-tools:
         specifier: ^2.20.0
         version: 2.24.1(typescript@5.9.3)
@@ -490,199 +490,199 @@ packages:
       lru-cache: 10.4.3
     dev: true
 
-  /@aws-sdk/client-kms@3.1092.0:
-    resolution: {integrity: sha512-J7OItS/0TfJ2BVRP4AX6yLYODnTOCOieMumzvusJhW7ojJsMh5OMpK8f7i/dn2A4cKWmoXnDxYfiZX+aslaAjw==}
+  /@aws-sdk/client-kms@3.1104.0:
+    resolution: {integrity: sha512-nAf/oxiYsyVwkMk793I6yrye5BFcnJmbLEXTG79yt+VENdFPSZKAVk4myWmU/0M2dKEj+VTxY8KQHFbsOtW5yg==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/credential-provider-node': 3.972.71
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-node': 3.972.78
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
-      '@smithy/fetch-http-handler': 5.6.9
-      '@smithy/node-http-handler': 4.9.9
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/core@3.976.0:
-    resolution: {integrity: sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==}
+  /@aws-sdk/core@3.977.6:
+    resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.974.2
-      '@aws-sdk/xml-builder': 3.972.36
+      '@aws-sdk/xml-builder': 3.972.37
       '@aws/lambda-invoke-store': 0.3.0
-      '@smithy/core': 3.29.7
-      '@smithy/signature-v4': 5.6.8
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
       '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-env@3.972.60:
-    resolution: {integrity: sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==}
+  /@aws-sdk/credential-provider-env@3.972.67:
+    resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-http@3.972.62:
-    resolution: {integrity: sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==}
+  /@aws-sdk/credential-provider-http@3.972.69:
+    resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
-      '@smithy/fetch-http-handler': 5.6.9
-      '@smithy/node-http-handler': 4.9.9
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-ini@3.973.5:
-    resolution: {integrity: sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw==}
+  /@aws-sdk/credential-provider-ini@3.973.12:
+    resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/credential-provider-env': 3.972.60
-      '@aws-sdk/credential-provider-http': 3.972.62
-      '@aws-sdk/credential-provider-login': 3.972.67
-      '@aws-sdk/credential-provider-process': 3.972.60
-      '@aws-sdk/credential-provider-sso': 3.973.4
-      '@aws-sdk/credential-provider-web-identity': 3.972.66
-      '@aws-sdk/nested-clients': 3.997.34
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-login': 3.972.74
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/nested-clients': 3.997.41
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
-      '@smithy/credential-provider-imds': 4.4.12
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-login@3.972.67:
-    resolution: {integrity: sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==}
+  /@aws-sdk/credential-provider-login@3.972.74:
+    resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/nested-clients': 3.997.34
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-node@3.972.71:
-    resolution: {integrity: sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==}
+  /@aws-sdk/credential-provider-node@3.972.78:
+    resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.60
-      '@aws-sdk/credential-provider-http': 3.972.62
-      '@aws-sdk/credential-provider-ini': 3.973.5
-      '@aws-sdk/credential-provider-process': 3.972.60
-      '@aws-sdk/credential-provider-sso': 3.973.4
-      '@aws-sdk/credential-provider-web-identity': 3.972.66
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-ini': 3.973.12
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
-      '@smithy/credential-provider-imds': 4.4.12
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-process@3.972.60:
-    resolution: {integrity: sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==}
+  /@aws-sdk/credential-provider-process@3.972.67:
+    resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-sso@3.973.4:
-    resolution: {integrity: sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA==}
+  /@aws-sdk/credential-provider-sso@3.973.11:
+    resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/nested-clients': 3.997.34
-      '@aws-sdk/token-providers': 3.1092.0
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/token-providers': 3.1103.0
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/credential-provider-web-identity@3.972.66:
-    resolution: {integrity: sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==}
+  /@aws-sdk/credential-provider-web-identity@3.972.73:
+    resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/nested-clients': 3.997.34
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/nested-clients@3.997.34:
-    resolution: {integrity: sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==}
+  /@aws-sdk/nested-clients@3.997.41:
+    resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
-      '@smithy/fetch-http-handler': 5.6.9
-      '@smithy/node-http-handler': 4.9.9
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/signature-v4-multi-region@3.996.41:
-    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+  /@aws-sdk/signature-v4-multi-region@3.996.43:
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.974.2
-      '@smithy/signature-v4': 5.6.8
+      '@smithy/signature-v4': 5.6.12
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@aws-sdk/token-providers@3.1092.0:
-    resolution: {integrity: sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==}
+  /@aws-sdk/token-providers@3.1103.0:
+    resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/core': 3.976.0
-      '@aws-sdk/nested-clients': 3.997.34
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
@@ -698,8 +698,8 @@ packages:
     dev: true
     optional: true
 
-  /@aws-sdk/xml-builder@3.972.36:
-    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+  /@aws-sdk/xml-builder@3.972.37:
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
     dependencies:
@@ -1496,7 +1496,7 @@ packages:
       eth-json-rpc-filters: 6.0.1
       eventemitter3: 5.0.4
       keccak: 3.0.4
-      preact: 10.29.7
+      preact: 10.29.8
       sha.js: 2.4.12
     transitivePeerDependencies:
       - preact-render-to-string
@@ -1729,8 +1729,8 @@ packages:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  /@emnapi/runtime@1.11.2:
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  /@emnapi/runtime@1.11.3:
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -3080,7 +3080,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     dev: true
     optional: true
 
@@ -3231,7 +3231,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/ws': 8.18.1
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5807,8 +5807,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@smithy/core@3.29.7:
-    resolution: {integrity: sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==}
+  /@smithy/core@3.31.1:
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
@@ -5817,45 +5817,45 @@ packages:
     dev: true
     optional: true
 
-  /@smithy/credential-provider-imds@4.4.12:
-    resolution: {integrity: sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q==}
+  /@smithy/credential-provider-imds@4.4.16:
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@smithy/fetch-http-handler@5.6.9:
-    resolution: {integrity: sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ==}
+  /@smithy/fetch-http-handler@5.6.13:
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@smithy/node-http-handler@4.9.9:
-    resolution: {integrity: sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==}
+  /@smithy/node-http-handler@4.9.13:
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@smithy/signature-v4@5.6.8:
-    resolution: {integrity: sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg==}
+  /@smithy/signature-v4@5.6.12:
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      '@smithy/core': 3.29.7
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
     dev: true
@@ -7406,7 +7406,7 @@ packages:
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7426,7 +7426,7 @@ packages:
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
       '@solana/subscribable': 6.10.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7622,7 +7622,7 @@ packages:
       '@solana/rpc-spec': 3.0.3(typescript@5.9.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
-      undici-types: 7.28.0
+      undici-types: 7.29.0
     dev: true
 
   /@solana/rpc-transport-http@5.5.1(typescript@5.9.3):
@@ -7638,7 +7638,7 @@ packages:
       '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
       typescript: 5.9.3
-      undici-types: 7.28.0
+      undici-types: 7.29.0
 
   /@solana/rpc-transport-http@6.10.0(typescript@5.9.3):
     resolution: {integrity: sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==}
@@ -7654,7 +7654,7 @@ packages:
       '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
       typescript: 5.9.3
-      undici-types: 8.8.0
+      undici-types: 8.10.0
     dev: false
     optional: true
 
@@ -8531,7 +8531,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      '@toon-protocol/core': 3.1.3(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
+      '@toon-protocol/core': 3.2.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
       '@toon-protocol/sdk': 3.1.3(@types/react@19.2.17)(mina-signer@3.1.0)(react@19.2.8)(typescript@5.9.3)
       nostr-tools: 2.24.1(typescript@5.9.3)
       viem: 2.55.5(typescript@5.9.3)(zod@3.25.76)
@@ -8540,7 +8540,7 @@ packages:
       '@toon-protocol/mina-zkapp': 0.1.1
       mina-signer: 3.1.0
       o1js: 2.14.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8596,7 +8596,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      '@toon-protocol/core': 3.1.3(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
+      '@toon-protocol/core': 3.2.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
       '@toon-protocol/sdk': 3.1.3(@types/react@19.2.17)(mina-signer@3.1.0)(react@19.2.8)(typescript@5.9.3)
       nostr-tools: 2.24.1(typescript@5.9.3)
       viem: 2.55.5(typescript@5.9.3)(zod@3.25.76)
@@ -8605,7 +8605,7 @@ packages:
       '@toon-protocol/mina-zkapp': 0.1.1
       mina-signer: 3.1.0
       o1js: 2.14.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8652,8 +8652,8 @@ packages:
       - zod
     dev: true
 
-  /@toon-protocol/client@0.26.0(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-mb878Un/qQWjkqfFjcOJPSIGUYCwTNI3i38dnmqxCNhdlsn3mHJmsxUz6uzFackiG6A4S0qYR+uR9K38xhzaww==}
+  /@toon-protocol/client@0.29.0(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-98zydohZcCAv2w7yoAoWwBHtd6+3Un3f5pXZI26I7YfakOKqi4qXaKZdmBejiOZ+7mpaPhKG6RIprKEqqafxAw==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0
@@ -8661,7 +8661,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      '@toon-protocol/core': 3.1.4(typescript@5.9.3)
+      '@toon-protocol/core': 3.2.0(typescript@5.9.3)
       '@toon-protocol/sdk': 3.1.3(mina-signer@3.1.0)(typescript@5.9.3)
       nostr-tools: 2.24.1(typescript@5.9.3)
       viem: 2.55.5(typescript@5.9.3)(zod@3.25.76)
@@ -8670,7 +8670,7 @@ packages:
       '@toon-protocol/mina-zkapp': 0.1.1
       mina-signer: 3.1.0
       o1js: 2.14.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8757,7 +8757,7 @@ packages:
     optionalDependencies:
       '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
       '@ai-sdk/openai': 1.3.24(zod@3.25.76)
-      '@aws-sdk/client-kms': 3.1092.0
+      '@aws-sdk/client-kms': 3.1104.0
       '@azure/identity': 4.13.1
       '@azure/keyvault-keys': 4.10.2
       '@google-cloud/kms': 3.8.0
@@ -8797,7 +8797,7 @@ packages:
       arweave: 1.15.7
       nostr-tools: 2.24.1(typescript@5.9.3)
       simple-git: 3.36.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8859,7 +8859,7 @@ packages:
       arweave: 1.15.7
       nostr-tools: 2.24.1(typescript@5.9.3)
       simple-git: 3.36.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8922,7 +8922,7 @@ packages:
       arweave: 1.15.7
       nostr-tools: 2.24.1(typescript@5.9.3)
       simple-git: 3.36.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8984,7 +8984,7 @@ packages:
       arweave: 1.15.7
       nostr-tools: 2.24.1(typescript@5.9.3)
       simple-git: 3.36.0
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9029,8 +9029,70 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@toon-protocol/core@3.1.4(typescript@5.9.3):
-    resolution: {integrity: sha512-lSHNKuLoJz6eSDCDMXxtj6sjkOA0GJb7E713aT7lUcAOSM+hWR8t204XQTPSEQS1zNUMsMS/2IFEAitRKoIY1A==}
+  /@toon-protocol/core@3.2.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3):
+    resolution: {integrity: sha512-mNl4Oje+vz7g+C4nIHGRxB/W8/ySsFnaMN8kJkUsZ1muMgzl0srIskaauedWn4oMSC7pn1DXM7KVi9f0JW1yMw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@toon-protocol/connector': '>=3.3.3'
+    peerDependenciesMeta:
+      '@toon-protocol/connector':
+        optional: true
+    dependencies:
+      '@ardrive/turbo-sdk': 1.42.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3)
+      '@noble/hashes': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      '@toon-format/toon': 1.4.0
+      '@toon-protocol/settlement-digest': 1.0.0
+      arweave: 1.15.7
+      nostr-tools: 2.24.1(typescript@5.9.3)
+      simple-git: 3.36.0
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - preact-render-to-string
+      - react
+      - react-native
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+
+  /@toon-protocol/core@3.2.0(typescript@5.9.3):
+    resolution: {integrity: sha512-mNl4Oje+vz7g+C4nIHGRxB/W8/ySsFnaMN8kJkUsZ1muMgzl0srIskaauedWn4oMSC7pn1DXM7KVi9f0JW1yMw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@toon-protocol/connector': '>=3.3.3'
@@ -9172,7 +9234,7 @@ packages:
       better-sqlite3: 11.10.0
       hono: 4.12.31
       nostr-tools: 2.24.1(typescript@5.9.3)
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12094,7 +12156,7 @@ packages:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.2
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -15699,8 +15761,8 @@ packages:
   /preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
-  /preact@10.29.7:
-    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+  /preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
     peerDependencies:
       preact-render-to-string: '>=5'
     peerDependenciesMeta:
@@ -17529,11 +17591,11 @@ packages:
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  /undici-types@7.28.0:
-    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
+  /undici-types@7.29.0:
+    resolution: {integrity: sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==}
 
-  /undici-types@8.8.0:
-    resolution: {integrity: sha512-nNSnIK0VcEoNWrYwxCz9DFT1W7ASyBRWX7Hju/p9RAfVDcHoH07hkMg/na9U/2S04fhkPc4pDUK5NblZoaCvwg==}
+  /undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
     requiresBuild: true
     dev: false
     optional: true
@@ -18405,6 +18467,18 @@ packages:
     dependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+
+  /ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   /wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}


### PR DESCRIPTION
## Why

Both bumps are what turned the factory-job proof from failing to `PROOF COMPLETE`
(toon-protocol/rig#59, run 8, witnessed live on devnet today). Until now the `client` bump
lived only in an uncommitted working-tree edit that each proof run re-applied — the documented
trap 2 in the orchestration handoff.

- **`@toon-protocol/client` `^0.26.2` → `^0.29.0`.** A caret range on a `0.x` does not cross
  minors, so `pnpm install` resolved `0.26.0` for three runs. That predates toon-client#503,
  in which the client sent `config.btpPeerId ?? 'client'` and so bound under the literal
  registry key `"client"` — harmless before connector#743 made that key an address, fatal
  after: the PREPARE `F02`s at the Rust edge.
- **`@toon-protocol/core` `^3.1.2` → `^3.2.0`.** 3.2.0 carries the corrected devnet genesis
  peer seed (toon-protocol/toon#155). The 3.1.x seed pinned the retired TypeScript connector's
  nostr key `3f12da6d…`, and `ToonClient`'s bootstrap filters kind:10032 by `authors`, so a
  client got `EOSE, found 0 events` and could not open a channel at all.

## Evidence

Run 8, through the shipped bootstrap path with no local override:

```
[Bootstrap] Query filter: {"kinds":[10032],"authors":["30fdd01d55c3efeb…"],"limit":1}
[Bootstrap] EOSE received, found 1 events
[Bootstrap] Negotiated evm:84532 with nostr-30fdd01d55c3efeb
OK — provider's spendable headroom rose (100000 -> 110000)
OK — on-chain deposit is unchanged across the run (100000)
PROOF COMPLETE — one paid factory-job increment, end to end.
```

## Scope

`packages/rig` only. `pnpm update --recursive` also wanted to drag `packages/rig-web` from
`core@^1.6.0` to `^3.2.0` — two majors, nothing to do with this proof — so that file is
reverted and left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
