### PR TITLE
ci: forward issues:closed to the central unblock dispatcher (toon-meta#280)

### DIFF
--- a/.github/workflows/unblock-dispatcher-shim.yml
+++ b/.github/workflows/unblock-dispatcher-shim.yml
@@ -1,0 +1,42 @@
+# unblock-dispatcher shim — forwards this repo's issues:closed events to the
+# central dependency-driven dispatcher in toon-meta (toon-meta#280).
+#
+# CANONICAL COPY. This file is fanned out VERBATIM to every factory repo as
+# .github/workflows/unblock-dispatcher-shim.yml (toon-meta itself needs no
+# shim — its unblock-dispatcher.yml carries the same trigger directly). When
+# onboarding a new factory repo, copy this file unchanged; when changing it,
+# change it here first and re-fan-out.
+#
+# Same fleet event-forwarding convention as pr-housekeeping-shim.yml (thin
+# per-repo shim → toon-meta reusable workflow via workflow_call with
+# `secrets: inherit`), kept as a SIBLING file rather than folded into that
+# shim on purpose: the event sets are disjoint, the two roll out
+# independently, and a problem in one forwarder can never take down the
+# other.
+#
+# Why every close forwards (no local filter): whether a closed issue unblocks
+# anything is a property of the CROSS-REPO dependency graph, which only the
+# central dispatcher can see — a repo-local shim cannot know that its closed
+# issue is a blocker of a toon-meta epic child. The central pass is cheap,
+# full-fleet, and coalesced by its concurrency group, so forwarding
+# everything is correct and affordable. A dropped event is recovered by the
+# dispatcher's 6-hourly safety cron.
+#
+# Writes are gated centrally: until the org Actions variable DISPATCH_APPLY
+# is 'true', every forwarded run is a no-write dry-run report.
+
+name: unblock-dispatcher-shim
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  forward:
+    uses: toon-protocol/toon-meta/.github/workflows/unblock-dispatcher.yml@main
+    with:
+      source: ${{ format('{0}#{1}', github.repository, github.event.issue.number) }}
+    secrets: inherit


### PR DESCRIPTION
Thin forwarder: this repo's `issues: closed` events → toon-meta's central unblock dispatcher (reusable workflow via `workflow_call`, `secrets: inherit`). Whether a closed issue unblocks anything is a property of the CROSS-REPO dependency graph, which only the central pass can see — so every close forwards, and the dispatcher's 6-hourly safety cron recovers any dropped event. Same fleet event-forwarding convention as `pr-housekeeping-shim.yml`, kept as a sibling file so the two forwarders roll out independently.

**Merge order:** merge AFTER toon-protocol/toon-meta#300 lands the called workflow on toon-meta `main` — until then a forwarded run fails to resolve `unblock-dispatcher.yml@main`.

No writes fire from merging this: until the org Actions variable `DISPATCH_APPLY` is `'true'`, every forwarded run is a no-write dry-run report.

Part of toon-protocol/toon-meta#280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
