### PR TITLE
factory: approver — factory-ops submits the formal review verdict on agent PRs

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -181,6 +181,11 @@ jobs:
           # SANDCASTLE_AUTO_MERGE: "true"
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The formal-verdict approver (toon-meta#282). HOST-ONLY: it is
+          # deliberately NOT forwarded into the sandbox (see
+          # .sandcastle/sandbox-secrets.ts) — the agent must never hold the
+          # credential that approves its own output.
+          FACTORY_OPS_TOKEN: ${{ secrets.FACTORY_OPS_TOKEN }}
         run: pnpm sandcastle:implement
 
       # REDACT BEFORE UPLOAD — this repository is PUBLIC.
@@ -218,6 +223,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          FACTORY_OPS_TOKEN: ${{ secrets.FACTORY_OPS_TOKEN }}
         run: |
           set -euo pipefail
           [ -d .sandcastle ] || { echo "No .sandcastle directory — nothing to redact."; exit 0; }
@@ -228,7 +234,8 @@ jobs:
           # secret that contains another is not partially replaced).
           exact = sorted(
               (v for v in (os.environ.get(k, "") for k in
-                           ("GH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "APP_PRIVATE_KEY"))
+                           ("GH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "APP_PRIVATE_KEY",
+                            "FACTORY_OPS_TOKEN"))
                if v and len(v.strip()) >= 8),
               key=len, reverse=True,
           )

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -7,11 +7,18 @@
 #   and requires a structured verdict (toon-meta#275): the reviewer resolves the
 #   PR's target issue from its body's `Closes #n`, reviews against the issue's
 #   acceptance criteria, and must emit <review>{"verdict":"clean"|"blocking",
-#   ...}</review> — a malformed verdict FAILS the job. On "blocking" the runner
-#   posts the findings as a PR review and applies `needs:human` (both via the
-#   App token below — this workflow's own GITHUB_TOKEN stays read-only). It
-#   NEVER merges the PR and NEVER closes anything — a human still merges. It is a
-#   single-pass reviewer (one iteration), not a multi-round loop.
+#   ...}</review> — a malformed verdict FAILS the job. The verdict is then
+#   submitted FORMALLY as the factory-ops identity (toon-meta#282,
+#   FACTORY_OPS_TOKEN — provisioned + monitored under toon-meta#271): "clean" →
+#   a real APPROVE review (a machine verdict; see toon-meta's FACTORY.md,
+#   "What a factory-ops approval attests"), "blocking" → REQUEST_CHANGES with
+#   the findings plus `needs:human`. The approver must never be the PR author:
+#   the runner compares the token's login against the author before the
+#   reviewer runs and again at submission, and a missing/expired/wrong-identity
+#   token FAILS the job loudly instead of degrading to a COMMENTED review (the
+#   old loops' REVIEWER_TOKEN rot). This workflow's own GITHUB_TOKEN stays
+#   read-only. It NEVER merges the PR and NEVER closes anything — a human still
+#   merges. It is a single-pass reviewer (one iteration), not a multi-round loop.
 #
 #   Committing this file triggers nothing: pull_request-`labeled` workflows fire
 #   only when someone applies the label.
@@ -125,6 +132,11 @@ jobs:
           SANDCASTLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The formal-verdict approver (toon-meta#282). HOST-ONLY: it is
+          # deliberately NOT forwarded into the sandbox (see
+          # .sandcastle/sandbox-secrets.ts) — the agent must never hold the
+          # credential that approves its own output.
+          FACTORY_OPS_TOKEN: ${{ secrets.FACTORY_OPS_TOKEN }}
         run: pnpm sandcastle:review
 
       # REDACT BEFORE UPLOAD — this repository is PUBLIC.
@@ -162,6 +174,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          FACTORY_OPS_TOKEN: ${{ secrets.FACTORY_OPS_TOKEN }}
         run: |
           set -euo pipefail
           [ -d .sandcastle ] || { echo "No .sandcastle directory — nothing to redact."; exit 0; }
@@ -172,7 +185,8 @@ jobs:
           # secret that contains another is not partially replaced).
           exact = sorted(
               (v for v in (os.environ.get(k, "") for k in
-                           ("GH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "APP_PRIVATE_KEY"))
+                           ("GH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "APP_PRIVATE_KEY",
+                            "FACTORY_OPS_TOKEN"))
                if v and len(v.strip()) >= 8),
               key=len, reverse=True,
           )

--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -43,8 +43,9 @@ import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import { sandboxSecrets } from "./sandbox-secrets.ts";
 import {
-  postBlockingVerdict,
+  resolveFactoryOpsIdentity,
   runReviewerWithVerdict,
+  submitFactoryOpsVerdict,
 } from "./review-verdict.ts";
 
 // ---------------------------------------------------------------------------
@@ -65,6 +66,18 @@ const autoMerge = process.env.SANDCASTLE_AUTO_MERGE === "true";
 // Deterministic branch name, matching the planner's convention in main.ts so a
 // re-run of the same issue reuses the same branch and accumulated progress.
 const branch = `sandcastle/issue-${issueNumber}`;
+
+// PREFLIGHT the factory-ops approver credential (toon-meta#282) in PR mode,
+// BEFORE the expensive implement+review passes: the PR this runner opens gets
+// its formal verdict (APPROVE / REQUEST_CHANGES) submitted as factory-ops, so
+// a missing/expired FACTORY_OPS_TOKEN should fail the job in seconds, not
+// after a full sandcastle run. The author≠approver guard runs at submission
+// time (the PR — and hence its author — does not exist yet). Auto-merge mode
+// merges directly with no PR, so it needs no approver.
+if (process.env.SANDCASTLE_AUTO_MERGE !== "true") {
+  const preflight = resolveFactoryOpsIdentity();
+  console.log(`Approver preflight OK: factory-ops is '${preflight.login}'.`);
+}
 
 // Fetch the issue title on the host so we can pass it to the prompts and name
 // the PR. `gh` authenticates via GH_TOKEN in the environment.
@@ -255,15 +268,21 @@ try {
     if (openPrs.length > 0) {
       const pr = openPrs[0]!;
       console.log(`\nVerified: PR #${pr.number} is open — ${pr.url}`);
-      // A blocking verdict lands on the PR now that it exists: findings as a
-      // PR review, plus the `needs:human` label (toon-meta#275).
-      if (blocking) {
-        postBlockingVerdict(String(pr.number), review.verdict, {
-          number: issueNumber,
-          title: issueTitle,
-        });
-      }
-      console.log("Awaiting human review.");
+      // The formal verdict lands on the PR now that it exists, submitted as
+      // factory-ops (toon-meta#282): clean → APPROVE (a machine verdict —
+      // see toon-meta's FACTORY.md, "What a factory-ops approval attests");
+      // blocking → REQUEST_CHANGES with the findings plus `needs:human`
+      // (toon-meta#275). The author≠approver guard runs inside the submission
+      // and fails the job loudly rather than degrading to a COMMENTED review.
+      submitFactoryOpsVerdict(String(pr.number), review.verdict, {
+        number: issueNumber,
+        title: issueTitle,
+      });
+      console.log(
+        blocking
+          ? "Blocking findings requested changes — a human decides."
+          : "Formal approval submitted.",
+      );
     } else {
       // No open PR. Gather diagnostics (all via the authenticated host `gh`).
       const nwo = execFileSync(

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -10,9 +10,17 @@
 //   - the reviewer must emit <review>{"verdict":"clean"|"blocking",
 //     "blockingFindings":[{file,line,summary,why}]}</review>; a malformed
 //     verdict fails the run (one engine-style resume retry, then non-zero exit)
-//   - on "blocking", the findings are posted as a PR review and the
-//     `needs:human` label is applied
-// It NEVER merges the PR and NEVER closes anything — a human still merges.
+// The verdict is then submitted FORMALLY as the factory-ops identity
+// (toon-meta#282, FACTORY_OPS_TOKEN):
+//   - "clean"    → a real APPROVE review (a machine verdict — see toon-meta's
+//     FACTORY.md, "What a factory-ops approval attests")
+//   - "blocking" → a REQUEST_CHANGES review carrying the findings, plus the
+//     `needs:human` label
+// The approver must never be the PR author: the identity is resolved and
+// compared against the author BEFORE the reviewer runs (fail fast) and again
+// at submission; a missing/expired/wrong-identity token FAILS the job loudly
+// rather than degrading to a COMMENTED review.
+// It NEVER merges the PR and NEVER closes anything.
 //
 // STANDALONE-REVIEW MECHANICS (proven live on connector#634's first run):
 //   Sandcastle checks the PR head branch out in its OWN worktree under
@@ -43,9 +51,12 @@ import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import { sandboxSecrets } from "./sandbox-secrets.ts";
 import {
-  postBlockingVerdict,
+  assertApproverIsNotAuthor,
+  getPrAuthorLogin,
+  resolveFactoryOpsIdentity,
   resolveIssueFromPrBody,
   runReviewerWithVerdict,
+  submitFactoryOpsVerdict,
   type ReviewVerdict,
 } from "./review-verdict.ts";
 
@@ -74,6 +85,17 @@ if (!headRef) {
 execFileSync("git", ["fetch", "origin", `+${headRef}:${headRef}`], {
   stdio: "inherit",
 });
+
+// PREFLIGHT the factory-ops approver identity (toon-meta#282) BEFORE the
+// expensive reviewer pass: a missing/expired FACTORY_OPS_TOKEN, or one that
+// authenticates as the PR's own author, fails the job here in seconds instead
+// of after a full opus review. The submission path re-asserts the same guard.
+const prAuthor = getPrAuthorLogin(prNumber);
+const factoryOps = resolveFactoryOpsIdentity();
+assertApproverIsNotAuthor(factoryOps, prAuthor);
+console.log(
+  `Approver preflight OK: factory-ops is '${factoryOps.login}', PR author is '${prAuthor}'.`,
+);
 
 // Resolve the Spec-axis target issue from the PR body's `Closes #n`.
 const targetIssue = resolveIssueFromPrBody(prNumber);
@@ -207,12 +229,20 @@ try {
 }
 
 // The verdict's side effects run AFTER the sandbox is closed, from the
-// authenticated host: findings must land on the PR even if the push
-// verification below is about to fail the job.
+// authenticated host. Blocking findings must land on the PR even if the push
+// verification below is about to fail the job; a clean APPROVAL must NOT be
+// submitted on a failing run — an approval green-lights a merge, and
+// approving from a red job would let auto-merge proceed past the failure.
 if (verdict.verdict === "blocking") {
-  postBlockingVerdict(prNumber, verdict, targetIssue);
+  submitFactoryOpsVerdict(prNumber, verdict, targetIssue);
+} else if (reviewPushError) {
+  console.error(
+    "\nVerdict clean, but the review-push verification failed — NOT " +
+      "submitting the factory-ops approval on a failing run.",
+  );
 } else {
-  console.log("\nVerdict clean — no blocking findings.");
+  console.log("\nVerdict clean — submitting the factory-ops approval.");
+  submitFactoryOpsVerdict(prNumber, verdict, targetIssue);
 }
 
 // Fail loud AFTER the sandbox is closed: a silently-failed review push must turn

--- a/.sandcastle/review-verdict.ts
+++ b/.sandcastle/review-verdict.ts
@@ -293,19 +293,138 @@ export function resolveIssueFromPrBody(prNumber: string): TargetIssue | null {
 
 const NEEDS_HUMAN_LABEL = "needs:human";
 
+// ---------------------------------------------------------------------------
+// factory-ops formal verdict (toon-meta#282)
+//
+// The factory App (toon-backlog-bot) opens agent PRs, and GitHub forbids a
+// PR's author from approving it — so the formal review verdict is submitted by
+// a SECOND identity: factory-ops, authenticating via the FACTORY_OPS_TOKEN
+// org secret (provisioned + monitored under toon-meta#271,
+// .github/workflows/factory-ops-credential.yml).
+//
+//   clean    → a real APPROVE review (satisfies required-review protection)
+//   blocking → a REQUEST_CHANGES review carrying the findings, + needs:human
+//
+// The approval is a MACHINE verdict: it attests that the gate passed and the
+// reviewer found nothing blocking — not human judgement. See FACTORY.md,
+// "What a factory-ops approval attests".
+//
+// FAIL LOUDLY, NEVER DEGRADE: if the token is missing (an unshared org secret
+// is an EMPTY STRING at runtime, not an error), does not authenticate
+// (expired/revoked/pending org approval), or authenticates AS the PR author,
+// every function here THROWS so the job goes red. The retired loops' reviewer
+// rotted precisely because REVIEWER_TOKEN expired and reviews silently
+// degraded to a COMMENTED verdict that satisfied nothing — that degradation
+// path must not exist here, so the submitted review's state is also read back
+// and verified.
+// ---------------------------------------------------------------------------
+
+export interface FactoryOpsIdentity {
+  /** The FACTORY_OPS_TOKEN value, used as GH_TOKEN for verdict submission. */
+  token: string;
+  /** The login the token authenticates as, e.g. "ALLiDoizCode". */
+  login: string;
+}
+
 /**
- * Post a blocking verdict's findings as a PR review (event COMMENT) and apply
- * the `needs:human` label. Pure REST via `gh api` — porcelain `gh pr edit` is
- * broken in repos with a classic Project attached (projectCards GraphQL
- * deprecation), so label writes must not go through it.
+ * Normalize an actor login for identity comparison. The same App author
+ * renders as `app/toon-backlog-bot` via GraphQL (`gh pr view --json author`)
+ * and `toon-backlog-bot[bot]` via REST — strip both decorations and casing so
+ * the self-approval guard cannot be dodged by a representation mismatch.
  */
-export function postBlockingVerdict(
-  prNumber: string,
+export function normalizeLogin(login: string): string {
+  return login
+    .trim()
+    .toLowerCase()
+    .replace(/^app\//, "")
+    .replace(/\[bot\]$/, "");
+}
+
+/**
+ * Resolve the factory-ops approver identity, or THROW (fail the job) when the
+ * credential is missing or does not authenticate. Call this as early as
+ * possible — a rotten credential should fail the run before an expensive
+ * reviewer pass, not after it.
+ */
+export function resolveFactoryOpsIdentity(): FactoryOpsIdentity {
+  const token = process.env.FACTORY_OPS_TOKEN?.trim();
+  if (!token) {
+    throw new Error(
+      `FACTORY_OPS_TOKEN is missing or empty. The formal review verdict ` +
+        `(toon-meta#282) cannot be submitted without the factory-ops identity. ` +
+        `An org secret that is not shared with this repository is an empty ` +
+        `string at runtime, not an error — check org Settings -> Secrets and ` +
+        `variables -> Actions -> FACTORY_OPS_TOKEN -> Repository access, and ` +
+        `the workflow step's env wiring. Failing loudly instead of degrading ` +
+        `to a COMMENTED verdict (that silent degradation is how the retired ` +
+        `loops' reviewer rotted when REVIEWER_TOKEN expired).`,
+    );
+  }
+  let login = "";
+  try {
+    login = execFileSync("gh", ["api", "user", "--jq", ".login"], {
+      encoding: "utf8",
+      env: { ...process.env, GH_TOKEN: token },
+    }).trim();
+  } catch {
+    login = "";
+  }
+  if (!login) {
+    throw new Error(
+      `FACTORY_OPS_TOKEN did not authenticate. It may be revoked, expired, or ` +
+        `still pending org approval (a fine-grained PAT against an org sits ` +
+        `unusable until an org owner approves it). The credential monitor ` +
+        `(.github/workflows/factory-ops-credential.yml, toon-meta#271) should ` +
+        `have warned about this. Failing loudly — the formal review verdict ` +
+        `must never silently degrade.`,
+    );
+  }
+  return { token, login };
+}
+
+/** The PR's author login (GraphQL shape, e.g. `app/toon-backlog-bot`). */
+export function getPrAuthorLogin(prNumber: string): string {
+  const author = gh([
+    "pr",
+    "view",
+    prNumber,
+    "--json",
+    "author",
+    "--jq",
+    ".author.login",
+  ]).trim();
+  if (!author) {
+    throw new Error(`Could not resolve the author of PR #${prNumber}.`);
+  }
+  return author;
+}
+
+/**
+ * The self-approval guard: the approver must never be the PR author. GitHub
+ * would reject the APPROVE/REQUEST_CHANGES with a 422 anyway — this asserts
+ * the invariant BEFORE submitting, with a diagnosis instead of an API error.
+ */
+export function assertApproverIsNotAuthor(
+  approver: FactoryOpsIdentity,
+  prAuthorLogin: string,
+): void {
+  if (normalizeLogin(approver.login) === normalizeLogin(prAuthorLogin)) {
+    throw new Error(
+      `Self-approval guard: FACTORY_OPS_TOKEN authenticates as ` +
+        `'${approver.login}', which IS the PR author ('${prAuthorLogin}'). ` +
+        `GitHub forbids a PR's author from approving it, so submitting this ` +
+        `verdict could only produce a worthless COMMENTED review or a 422. ` +
+        `Failing the job loudly instead. Fix: point FACTORY_OPS_TOKEN at an ` +
+        `identity distinct from whatever opens agent PRs (the factory App), ` +
+        `or investigate why this PR was not opened by the App.`,
+    );
+  }
+}
+
+function factoryOpsFindingsBody(
   verdict: ReviewVerdict,
   issue: TargetIssue | null,
-): void {
-  const nwo = repoNwo();
-
+): string {
   const findings = verdict.blockingFindings
     .map(
       (f, i) =>
@@ -314,7 +433,7 @@ export function postBlockingVerdict(
     )
     .join("\n");
 
-  const body =
+  return (
     `## Reviewer verdict: BLOCKING\n\n` +
     (issue
       ? `Reviewed against issue #${issue.number} ("${issue.title}") and its acceptance criteria.\n\n`
@@ -322,53 +441,127 @@ export function postBlockingVerdict(
     `The sandcastle reviewer found ${verdict.blockingFindings.length} blocking finding(s):\n\n` +
     `${findings}\n\n` +
     `Applied \`${NEEDS_HUMAN_LABEL}\` — a human must resolve these findings before merge. ` +
-    `(Structured reviewer verdict, toon-protocol/toon-meta#275.)`;
+    `(Machine verdict submitted by factory-ops; toon-protocol/toon-meta#275, #282.)`
+  );
+}
 
-  execFileSync(
+function factoryOpsApprovalBody(issue: TargetIssue | null): string {
+  return (
+    `## Reviewer verdict: CLEAN — approved by factory-ops\n\n` +
+    `This approval is a **machine verdict**: it attests that the gate passed ` +
+    `and the sandcastle reviewer found nothing blocking` +
+    (issue
+      ? ` (reviewed against issue #${issue.number}, "${issue.title}", and its acceptance criteria)`
+      : ` (Standards-only review — no target issue resolved from the PR body)`) +
+    `. It is not human judgement. ` +
+    `See FACTORY.md, "What a factory-ops approval attests" ` +
+    `(toon-protocol/toon-meta#282).`
+  );
+}
+
+/**
+ * Submit the formal review verdict on a PR AS FACTORY-OPS:
+ *   clean    → APPROVE
+ *   blocking → REQUEST_CHANGES with the findings, plus the `needs:human` label
+ *
+ * Resolves the approver identity and re-asserts the self-approval guard
+ * itself, so no caller can reach the submission without the guard. After
+ * submission the created review's state is verified from the API response —
+ * anything other than the expected APPROVED/CHANGES_REQUESTED state (i.e. a
+ * degraded COMMENTED review) throws.
+ *
+ * Label writes are pure REST via `gh api` — porcelain `gh pr edit` is broken
+ * in repos with a classic Project attached (projectCards GraphQL deprecation).
+ * The `needs:human` label logic lives HERE and only here (toon-meta#282 seam:
+ * the pre-#282 COMMENT-review path applied it too; that path is gone).
+ */
+export function submitFactoryOpsVerdict(
+  prNumber: string,
+  verdict: ReviewVerdict,
+  issue: TargetIssue | null,
+): void {
+  const approver = resolveFactoryOpsIdentity();
+  const prAuthor = getPrAuthorLogin(prNumber);
+  assertApproverIsNotAuthor(approver, prAuthor);
+
+  const nwo = repoNwo();
+  const blocking = verdict.verdict === "blocking";
+  const event = blocking ? "REQUEST_CHANGES" : "APPROVE";
+  const expectedState = blocking ? "CHANGES_REQUESTED" : "APPROVED";
+  const body = blocking
+    ? factoryOpsFindingsBody(verdict, issue)
+    : factoryOpsApprovalBody(issue);
+
+  console.log(
+    `Submitting formal ${event} review as factory-ops ('${approver.login}') ` +
+      `on PR #${prNumber} (author: '${prAuthor}').`,
+  );
+
+  const response = execFileSync(
     "gh",
     [
       "api",
       `repos/${nwo}/pulls/${prNumber}/reviews`,
       "-f",
-      "event=COMMENT",
+      `event=${event}`,
       "-f",
       `body=${body}`,
     ],
-    { stdio: ["ignore", "ignore", "inherit"] },
+    { encoding: "utf8", env: { ...process.env, GH_TOKEN: approver.token } },
   );
 
-  // Ensure the label exists (ignore "already exists"), then add it. Both are
-  // plain REST so a pre-existing label or a re-run stays idempotent.
-  try {
+  // NEVER DEGRADE: verify the review GitHub actually created is in the state
+  // we asked for. A COMMENTED review here would be exactly the old
+  // REVIEWER_TOKEN rot, reborn — fail instead.
+  const created = JSON.parse(response) as { state?: string; id?: number };
+  if (created.state !== expectedState) {
+    throw new Error(
+      `Formal verdict DEGRADED: asked GitHub for ${event} but the created ` +
+        `review (id ${created.id ?? "?"}) has state ` +
+        `'${created.state ?? "unknown"}' instead of '${expectedState}'. ` +
+        `Refusing to treat this as success.`,
+    );
+  }
+  console.log(
+    `Verified: review ${created.id} on PR #${prNumber} is ${created.state}.`,
+  );
+
+  if (blocking) {
+    // Ensure the label exists (ignore "already exists"), then add it. Both are
+    // plain REST so a pre-existing label or a re-run stays idempotent.
+    try {
+      execFileSync(
+        "gh",
+        [
+          "api",
+          `repos/${nwo}/labels`,
+          "-f",
+          `name=${NEEDS_HUMAN_LABEL}`,
+          "-f",
+          "color=B60205",
+          "-f",
+          "description=Factory reviewer found blocking defects - a human must decide",
+        ],
+        { stdio: "pipe", env: { ...process.env, GH_TOKEN: approver.token } },
+      );
+    } catch {
+      // Label already exists — the normal case.
+    }
     execFileSync(
       "gh",
       [
         "api",
-        `repos/${nwo}/labels`,
+        `repos/${nwo}/issues/${prNumber}/labels`,
         "-f",
-        `name=${NEEDS_HUMAN_LABEL}`,
-        "-f",
-        "color=B60205",
-        "-f",
-        "description=Factory reviewer found blocking defects - a human must decide",
+        `labels[]=${NEEDS_HUMAN_LABEL}`,
       ],
-      { stdio: "pipe" },
+      {
+        stdio: ["ignore", "ignore", "inherit"],
+        env: { ...process.env, GH_TOKEN: approver.token },
+      },
     );
-  } catch {
-    // Label already exists — the normal case.
+    console.log(
+      `Requested changes with the findings and applied '${NEEDS_HUMAN_LABEL}' on PR #${prNumber}.`,
+    );
   }
-  execFileSync(
-    "gh",
-    [
-      "api",
-      `repos/${nwo}/issues/${prNumber}/labels`,
-      "-f",
-      `labels[]=${NEEDS_HUMAN_LABEL}`,
-    ],
-    { stdio: ["ignore", "ignore", "inherit"] },
-  );
-
-  console.log(
-    `Posted blocking findings as a PR review and applied '${NEEDS_HUMAN_LABEL}' on PR #${prNumber}.`,
-  );
 }

--- a/.sandcastle/sandbox-secrets.ts
+++ b/.sandcastle/sandbox-secrets.ts
@@ -36,6 +36,11 @@
 // `mergeProviderEnv` layers sandbox-provider env OVER the resolved `.env` values.
 
 // Host env vars that must reach claude-code and `gh`/`git` inside the sandbox.
+//
+// FACTORY_OPS_TOKEN is DELIBERATELY absent: it is the identity that submits
+// the formal review verdict on agent PRs (toon-meta#282), and the sandboxed
+// agent must never hold the credential that approves its own output. It stays
+// host-only (read by .sandcastle/review-verdict.ts after the sandbox closes).
 const PASSTHROUGH_KEYS = [
   "CLAUDE_CODE_OAUTH_TOKEN", // Claude Max-plan credential -> authenticates claude-code
   "GH_TOKEN", // in-sandbox `git push` / `gh pr create` / `gh issue list`


### PR DESCRIPTION
Port of the toon-meta#282 factory-ops approver (canonical change: toon-protocol/toon-meta#303) to this repo's `.sandcastle` runners and agent workflows.

- **clean** verdict → a real `APPROVE` review submitted as the factory-ops identity (`FACTORY_OPS_TOKEN`) — a machine verdict attesting "the gate passed and the reviewer found nothing blocking" (see toon-meta `FACTORY.md`, "What a factory-ops approval attests").
- **blocking** verdict → `REQUEST_CHANGES` carrying the findings (upgraded from #275's COMMENT event) plus `needs:human`; the label logic now lives once, inside the submission seam.
- **Self-approval guard**: the approver must never be the PR author; logins are normalized across GraphQL `app/<slug>` and REST `<slug>[bot]` shapes, checked before the reviewer runs and again at submission.
- **Fail loudly, never degrade**: missing/expired/wrong-identity token, or a created review whose state is not the expected `APPROVED`/`CHANGES_REQUESTED`, throws — no silent COMMENTED fallback (the retired loops' REVIEWER_TOKEN rot).
- A clean approval is not submitted on a run whose review-push verification failed.
- `FACTORY_OPS_TOKEN` is host-only (never forwarded into the sandbox) and added to the log-redaction exact-value pass.

Part of toon-protocol/toon-meta#270
Part of toon-protocol/toon-meta#282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
