### PR TITLE
factory: a clean verdict clears the needs:human it applied, and only that one

### DIFF
--- a/.sandcastle/needs-human-evaluator.mjs
+++ b/.sandcastle/needs-human-evaluator.mjs
@@ -1,0 +1,80 @@
+// needs:human ownership evaluator (toon-meta#352).
+//
+// Answers one question: WHO most recently put `needs:human` on this PR — the
+// factory-ops approver, or a person? Pure logic, no I/O; the caller passes the
+// timeline events in. Tests: needs-human-evaluator.test.mjs (node --test).
+//
+// ── WHY THIS DISTINCTION IS THE WHOLE FIX ───────────────────────────────────
+// The reviewer's BLOCKING branch applies `needs:human` as a side effect
+// (.sandcastle/review-verdict.ts, toon-meta#282). Nothing removed it, so a PR
+// that went blocking → fixed → clean ended up APPROVED *and* labelled — and
+// `auto-merge.yml` refuses on the label. Once blocked, gated forever. On
+// 2026-08-12 that held three approved PRs simultaneously, one of which was the
+// fix for the sibling dead-`agent:implement` wedge (#330/#333).
+//
+// The naive fix — "a clean verdict clears the label" — trades that bug for a
+// worse one: `needs:human` is a HUMAN control point (FACTORY.md), so clearing
+// it unconditionally lets a machine overrule a person who applied it
+// deliberately. Hence ownership, not mere presence, decides.
+//
+// ── WHY THE TIMELINE AND NOT THE LABEL LIST ─────────────────────────────────
+// The label list says only THAT the label is present, never WHO applied it.
+// `labeled`/`unlabeled` events carry the actor, and are returned oldest-first,
+// so the LAST event for this label is the live state: `labeled` means applied
+// (by that actor), `unlabeled` means currently absent.
+//
+// ── WHY THIS LIVES IN .sandcastle/ AND NOT scripts/factory/ ─────────────────
+// It is imported by `review-verdict.ts`, which EVERY factory repo carries its
+// own copy of. `scripts/factory/` exists only in toon-meta, so an evaluator
+// living there could never be propagated — the import would not resolve in the
+// other nine repos, which is exactly the trap this file was moved out of.
+// Keeping it beside its only caller means the pair travels as a unit.
+//
+// Its test still lives at `scripts/factory/needs-human-evaluator.test.mjs`,
+// because that is the glob `npm run test:factory` runs, and imports across the
+// boundary. When propagating to another repo, copy THIS file and
+// `review-verdict.ts` together; the test comes only if that repo runs one.
+
+/** The label this module reasons about. */
+export const NEEDS_HUMAN_LABEL = "needs:human";
+
+/**
+ * The login that most recently applied `needs:human`, or `null` if the label
+ * is not currently on the PR.
+ *
+ * @param {Array<{event?: string, label?: {name?: string}, actor?: {login?: string}}>} timeline
+ *   Timeline events, oldest first, as GitHub returns them. Entries that are
+ *   not `labeled`/`unlabeled` for this label are ignored, so the raw timeline
+ *   can be passed straight in.
+ * @returns {string | null}
+ */
+export function lastNeedsHumanApplier(timeline) {
+  if (!Array.isArray(timeline)) return null;
+
+  let applier = null;
+  for (const entry of timeline) {
+    if (!entry || entry.label?.name !== NEEDS_HUMAN_LABEL) continue;
+    if (entry.event === "labeled") applier = entry.actor?.login ?? null;
+    else if (entry.event === "unlabeled") applier = null;
+  }
+  return applier;
+}
+
+/**
+ * Should a CLEAN verdict clear `needs:human` from this PR?
+ *
+ * True only when the label is currently applied AND the approver identity is
+ * the one that applied it. Fails closed: an unknown or human applier keeps the
+ * label. A label that should have been cleared costs a manual edit; one
+ * cleared wrongly overrules a person's decision, so the asymmetry is
+ * deliberate.
+ *
+ * @param {Array<object>} timeline Timeline events, oldest first.
+ * @param {string} approverLogin The factory-ops approver identity.
+ * @returns {boolean}
+ */
+export function shouldClearNeedsHuman(timeline, approverLogin) {
+  if (!approverLogin) return false;
+  const applier = lastNeedsHumanApplier(timeline);
+  return applier !== null && applier === approverLogin;
+}

--- a/.sandcastle/review-verdict.ts
+++ b/.sandcastle/review-verdict.ts
@@ -29,6 +29,7 @@
 import { execFileSync } from "node:child_process";
 import * as sandcastle from "@ai-hero/sandcastle";
 import { z } from "zod";
+import { shouldClearNeedsHuman } from "./needs-human-evaluator.mjs";
 
 // ---------------------------------------------------------------------------
 // Schema + Output declaration
@@ -475,6 +476,44 @@ function factoryOpsApprovalBody(issue: TargetIssue | null): string {
  * The `needs:human` label logic lives HERE and only here (toon-meta#282 seam:
  * the pre-#282 COMMENT-review path applied it too; that path is gone).
  */
+/**
+ * Whether a CLEAN verdict should clear `needs:human` from this PR
+ * (toon-meta#352).
+ *
+ * The decision itself is pure and lives in
+ * `.sandcastle/needs-human-evaluator.mjs`, unit-tested by
+ * `npm run test:factory` — this is only the I/O that feeds it. That split is
+ * this repo's convention (see the reap/unblock/dispatch evaluators), and it is
+ * the reason the ownership rule is testable at all.
+ *
+ * Reads the TIMELINE, not the label list: the label list says only THAT the
+ * label is present, never WHO applied it, and ownership is the whole
+ * distinction — a machine-applied label is stale state, a human-applied one is
+ * a decision.
+ *
+ * Fails closed on any read error: leaving the label costs a manual edit,
+ * clearing it wrongly overrules a person.
+ */
+function clearsNeedsHuman(prNumber: string, approverLogin: string, token: string): boolean {
+  try {
+    const raw = execFileSync(
+      "gh",
+      ["api", "--paginate", `repos/${repoNwo()}/issues/${prNumber}/timeline`],
+      { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, GH_TOKEN: token } },
+    ).toString();
+
+    // `--paginate` concatenates one JSON array per page; normalise to one array.
+    const events = raw
+      .split("\n")
+      .filter((line) => line.trim().startsWith("["))
+      .flatMap((line) => JSON.parse(line) as unknown[]);
+
+    return shouldClearNeedsHuman(events, approverLogin);
+  } catch {
+    return false;
+  }
+}
+
 export function submitFactoryOpsVerdict(
   prNumber: string,
   verdict: ReviewVerdict,
@@ -562,6 +601,42 @@ export function submitFactoryOpsVerdict(
     );
     console.log(
       `Requested changes with the findings and applied '${NEEDS_HUMAN_LABEL}' on PR #${prNumber}.`,
+    );
+  } else if (clearsNeedsHuman(prNumber, approver.login, approver.token)) {
+    // The machine clears what the machine applied, and only that (toon-meta#352).
+    //
+    // The blocking branch above applies `needs:human` as a side effect. Nothing
+    // used to remove it, so a PR that went blocking -> fixed -> clean ended
+    // APPROVED *and* carrying the label — and `auto-merge.yml` refuses on it
+    // ("needs-human: PR carries needs:human"). Once blocked, gated forever.
+    // On 2026-08-12 that held three approved PRs at once, including #333, the
+    // fix for the sibling dead-`agent:implement` wedge.
+    //
+    // The guard is the whole point: `needs:human` is a HUMAN control point
+    // (FACTORY.md). Clearing it unconditionally on a clean verdict would let a
+    // machine overrule a person who applied it deliberately — trading one bug
+    // for a worse one. So we remove it ONLY when the most recent application
+    // was by the approver identity itself. A human's label is never touched,
+    // and a human who re-applies it after a clean verdict keeps it.
+    execFileSync(
+      "gh",
+      [
+        "api",
+        "-X",
+        "DELETE",
+        // The colon MUST stay percent-encoded. `gh api` does not encode path
+        // segments, and an unencoded `needs:human` silently no-ops (200, no
+        // change) rather than erroring.
+        `repos/${nwo}/issues/${prNumber}/labels/${encodeURIComponent(NEEDS_HUMAN_LABEL)}`,
+      ],
+      {
+        stdio: ["ignore", "ignore", "inherit"],
+        env: { ...process.env, GH_TOKEN: approver.token },
+      },
+    );
+    console.log(
+      `Cleared '${NEEDS_HUMAN_LABEL}' on PR #${prNumber} — it was applied by ` +
+        `${approver.login} on a previous blocking verdict, and this verdict is clean.`,
     );
   }
 }


### PR DESCRIPTION
Propagation of [toon-meta#353](https://github.com/toon-protocol/toon-meta/pull/353) and [toon-meta#354](https://github.com/toon-protocol/toon-meta/pull/354) into this repo. No behaviour of this repo's own product changes — only the two `.sandcastle/` files that carry the factory fix.

## The wedge

The reviewer's **BLOCKING** verdict applies `needs:human` as a side effect (toon-meta#282). Nothing ever removed it.

So a PR that went **blocking → fixed → clean** ended up `APPROVED` *and* still carrying the label — and `auto-merge.yml` refuses on exactly that label (`needs-human: PR carries needs:human`). Once blocked, gated forever. Structurally the same defect as the dead-`agent:implement` wedge: a label applied by an automated step that no automated step ever clears.

It stranded **connector#923** and **connector#935**, both of which had to be cleared by hand. The clear could not fire there because connector still carries the old `review-verdict.ts` — which is the whole reason this propagation exists.

## Why ownership-gated and not presence-gated

The naive fix — "a clean verdict clears the label" — trades this bug for a worse one. `needs:human` is a **HUMAN control point** (FACTORY.md), so clearing it unconditionally would let a machine overrule a person who applied it deliberately.

So the clear fires only when the **most recent application of the label was by the approver identity itself**. A human's label is never touched, and a human who re-applies it after a clean verdict keeps it.

That distinction needs the **timeline**, not the label list: the label list says only *that* the label is present, never *who* applied it. `labeled`/`unlabeled` events carry the actor and arrive oldest-first, so the last event for the label is the live state.

It fails closed everywhere — an unreadable timeline, an unknown applier, a missing approver identity or a malformed event all leave the label alone. A label that should have been cleared costs a manual edit; one cleared wrongly overrules a person.

## What changed

- **`.sandcastle/needs-human-evaluator.mjs`** — new file, the pure ownership rule, copied verbatim from toon-meta. It sits beside its only caller (that was the point of toon-meta#354): `scripts/factory/` exists *only* in toon-meta, so the original import path resolved nowhere else and the fix was correct but unshippable.
- **`.sandcastle/review-verdict.ts`** — the import, a `clearsNeedsHuman()` helper that fetches the timeline, and an `else if` branch on the existing `if (blocking)`. **Additive only**: 75 inserted lines, nothing removed or reordered.

This repo's `review-verdict.ts` was byte-identical to toon-meta's pre-fix version, so the upstream patch applied cleanly and both files now match toon-meta `main` byte for byte.


## Verification

Gate green on this branch:

- `npx tsx .sandcastle/gate/correctness.ts` — **PASSED**, `eslint 0e/220w, typecheck 0e` against the frozen baseline `0e/220w, 0e`. No new violations.
- `pnpm -r build`, `pnpm -r typecheck` — clean
- `pnpm -r test` — pass (rig-web: 30 files, 357 passed / 12 skipped)

Import resolution confirmed with `npx tsx -e "import('./.sandcastle/review-verdict.ts')"` → `OK`. That is the check that would have caught toon-meta#354's unresolvable path, and it is the one thing a `.ts` → `.mjs` import can silently get wrong per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
