### PR TITLE
repair loop: dispatchable agent-fix + re-arm agent:review after a verified fix push

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -48,6 +48,21 @@ name: agent:fix
 on:
   pull_request:
     types: [labeled]
+  # Direct dispatch by the central PR repair pass (toon-meta's auto-merge.mjs)
+  # AFTER it applies `agent:fix`. This is not a convenience: a CONFLICTING PR
+  # has no merge ref, and GitHub does not fire `pull_request`-event workflows
+  # on a PR it cannot build a test merge for — so the labeled trigger above
+  # is structurally dead for the merge-conflict case, which is exactly the
+  # class toon-meta#357 calls the easy case (found live by the 2026-08-14
+  # repair drill on toon-meta#381: label applied, runner never fired). The
+  # pass therefore dispatches this workflow explicitly; the labeled trigger
+  # remains for red-check repairs and manual re-runs on mergeable PRs.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to repair (must already carry agent:fix)"
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -55,10 +70,11 @@ permissions:
 
 jobs:
   guard:
-    if: github.event.label.name == 'agent:fix'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'agent:fix'
     runs-on: ubuntu-latest
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
+      pr: ${{ steps.check.outputs.pr }}
     steps:
       - name: Evaluate guards
         id: check
@@ -66,9 +82,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.actor }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr }}
         run: |
           set -euo pipefail
           proceed=true
+          pr="${EVENT_PR:-${INPUT_PR:-}}"
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
+
+          # Dispatch path only: the label event proves label+branch via the
+          # pass that applied it; a dispatch must re-verify both, or a typo'd
+          # PR number runs the fixer against an arbitrary PR.
+          if [ -z "${EVENT_PR:-}" ]; then
+            info=$(gh api "repos/${REPO}/pulls/${pr}" --jq '{head: .head.ref, labels: [.labels[].name]}')
+            head=$(echo "$info" | jq -r .head)
+            case "$head" in
+              sandcastle/*|agent/*) ;;
+              *)
+                echo "::warning::PR #${pr} head '${head}' is not a factory branch — skipping."
+                proceed=false ;;
+            esac
+            if ! echo "$info" | jq -e '.labels | index("agent:fix")' >/dev/null; then
+              echo "::warning::PR #${pr} does not carry agent:fix — skipping."
+              proceed=false
+            fi
+          fi
 
           # The labeler must have write access — refuses drive-by repair
           # requests from outsiders. The PR repair pass itself labels via
@@ -95,7 +133,7 @@ jobs:
     # job budget even on a wall-clock kill.
     timeout-minutes: 30
     concurrency:
-      group: agent-fix-pr-${{ github.event.pull_request.number }}
+      group: agent-fix-pr-${{ github.event.pull_request.number || inputs.pr }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -132,7 +170,7 @@ jobs:
         # forensics steps still run.
         timeout-minutes: 25
         env:
-          SANDCASTLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          SANDCASTLE_PR_NUMBER: ${{ github.event.pull_request.number || needs.guard.outputs.pr }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm sandcastle:fix

--- a/.sandcastle/agent-fix-pr.ts
+++ b/.sandcastle/agent-fix-pr.ts
@@ -225,6 +225,39 @@ try {
         console.log(
           `\nVerified: PR branch '${headRef}' advanced to ${expectedSha} (the fix commits are pushed).`,
         );
+        // Re-arm the verdict loop (found live by the 2026-08-14 drill on
+        // toon-meta#381): the fix push creates a NEW head, the factory-ops
+        // approval stays anchored to the OLD one, and the auto-merge
+        // evaluator's approval-staleness guard then blocks the PR forever —
+        // nothing re-reviews on its own, because `agent:review` was cleared
+        // when the previous verdict landed (toon-meta#355). Applying it here
+        // fires the review pass on the repaired head, and a clean verdict
+        // re-opens the merge chain. Best-effort by design: if this fails,
+        // the PR sits approval-stale until a human applies the label — worse
+        // observability, no wrong writes — so log loudly, never throw (the
+        // fix itself is already pushed and verified).
+        try {
+          execFileSync(
+            "gh",
+            [
+              "api",
+              "-X",
+              "POST",
+              `repos/${nwo}/issues/${prNumber}/labels`,
+              "-f",
+              "labels[]=agent:review",
+            ],
+            { stdio: ["ignore", "ignore", "inherit"] },
+          );
+          console.log(
+            `Applied 'agent:review' to PR #${prNumber} — the repaired head needs a fresh verdict.`,
+          );
+        } catch (error) {
+          console.log(
+            `::warning::PR #${prNumber}: fix pushed, but applying 'agent:review' failed — ` +
+              `the PR will sit approval-stale until the label is applied by hand. ${String(error)}`,
+          );
+        }
       } else {
         pushVerificationError =
           `\nERROR: the fix phase reported COMPLETE, but the PR branch ` +


### PR DESCRIPTION
Propagates two toon-meta repair-loop fixes found live by the 2026-08-14 repair drill on toon-meta#381 (agent:fix applied to a conflicting PR — the runner never fired; and a repaired PR then sat approval-stale with nothing re-reviewing it).

## Change 1 — `.github/workflows/agent-fix.yml` (mirrors toon-meta#384)

A CONFLICTING PR has no merge ref, and GitHub delivers no `pull_request`-event workflows for it — so the `labeled` trigger is structurally dead for exactly the merge-conflict repair class. This adds a `workflow_dispatch` path with a required `pr` input; the fleet repair pass now dispatches this workflow directly after applying the label. On the dispatch path the guard re-verifies via the API that the PR carries `agent:fix` and a factory head branch (`sandcastle/*` / `agent/*`) — a typo'd PR number must not aim the fixer at an arbitrary PR. The actor write-permission guard stays on both paths. The concurrency group and `SANDCASTLE_PR_NUMBER` fall back to the dispatch input. The `labeled` trigger remains for red-check repairs and manual re-runs on mergeable PRs.

## Change 2 — `.sandcastle/agent-fix-pr.ts` (mirrors toon-meta#386)

The fix push creates a NEW head; the factory-ops approval stays anchored to the OLD one; the auto-merge evaluator's approval-staleness guard then blocks the PR — and nothing re-reviews on its own, because `agent:review` was cleared when the prior verdict landed. After the runner verifies the remote head advanced to the fixer's last commit, it now re-applies `agent:review` itself (best-effort: loud `::warning::` on failure, never throws — the fix is already pushed and verified).

## Verification

- YAML parses (`python3 yaml.safe_load`); the guard step's shell block passes `bash -n`.
- `esbuild --loader:.ts=ts .sandcastle/agent-fix-pr.ts` parses clean.
- Repo toolchain steps untouched; only these two files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
