### PR TITLE
rig push can never reach BTP (every paid write 401s), and each run leaks an on-chain channel

### DIFF
--- a/.changeset/paid-write-btp-and-channel-binding-key.md
+++ b/.changeset/paid-write-btp-and-channel-binding-key.md
@@ -13,13 +13,31 @@ precedence is HTTP-first, so every claim-bearing write went out as a
 which the live edge answers `401 Unauthorized: identity 'g.toon.client'
 failed to authenticate`, failing `rig push --yes` before any object uploaded.
 Resolution now ALSO adopts the payment peer's announced `btpEndpoint`
-(genesis seed as the fallback) whenever no uplink was pinned explicitly, and
-the embedded client is built with `preferBtpForPaidWrites` (toon-client#482)
-so claims ride the BTP session, which authenticates on connect. The proxy
-stays in place as the HTTP leg the x402 greeting bootstrap (connector #617)
-needs, and as the BTP transport's own fallback; an explicitly pinned
-`proxyUrl`/`btpUrl` is never overridden. Reads, fee estimates and the channel
-open are unchanged.
+whenever no uplink was pinned explicitly, and the embedded client is built
+with `preferBtpForPaidWrites` (toon-client#482) so claims ride the BTP
+session, which authenticates on connect. The proxy stays in place as the HTTP
+leg the x402 greeting bootstrap (connector #617) needs, and as the BTP
+transport's own fallback; an explicitly pinned `proxyUrl`/`btpUrl` is never
+overridden. Reads, fee estimates and the channel open are unchanged.
+
+When discovery names no BTP endpoint the fallback is a new
+`OFFICIAL_BTP_URL` — the RELAY box of the two-box devnet
+(`wss://proxy.relay.devnet.toonprotocol.dev/ilp/btp`, the publish route every
+push terminates at). Deliberately NOT `@toon-protocol/core`'s genesis seed,
+which still names the retired apex `proxy.devnet.toonprotocol.dev`: that host
+resolves but refuses connections since the two-box cutover, and the embedded
+client dials BTP during `start()`, so adopting it would turn a late 401 into
+rig refusing to run at all.
+
+Because a derived endpoint is only a discovery guess, an unreachable one now
+DEGRADES instead of failing the run: a bootstrap failure classified as a BTP
+socket/auth error (`isBtpTransportError`) on a derived endpoint rebuilds the
+publisher without the BTP leg and retries once over HTTP. An explicitly
+pinned `btpUrl` is never dropped — that is an operator's choice, and quietly
+abandoning it would hide a real misconfiguration. This shares the existing
+#279 cached-topology retry seam, now a bounded ordered chain of single-use
+recoveries (`bootstrapRecoveries`); bootstrap failures are pre-payment by
+construction, so no retry can double-pay.
 
 Note the client's own `requiredTransport` guard (toon-client#558) does not
 cover this case: not one live kind:10032 announce carries that field, so the
@@ -27,6 +45,13 @@ guard never fires against the current fleet. `@toon-protocol/client` is bumped
 to `^0.29.7` for the #558/#563 guards regardless — they are the second line of
 defence once an announce does declare it, and #563's 402-driven retry needs a
 `btpUrl` to retry ONTO, which is exactly what this change supplies.
+
+A further bump will be wanted once a client carrying toon-client#569
+(`Http401RequiresBtpError` — a 401→BTP retry, the exact failure seen here) and
+#571 (stop sending the unbacked `ILP-Peer-Id`, so the 401 never happens) is
+published; neither is on npm yet, and neither is needed for this fix to work.
+When they ship, rig could drop `preferBtpForPaidWrites` back to an opt-in and
+let HTTP-first stand, since the 401 would either not occur or self-recover.
 
 **Leaked on-chain payment channels.** `ChannelManager.peerChannels` is keyed
 by the composite binding key `<peerId>|<chain>|<tokenNetwork>`

--- a/.changeset/paid-write-btp-and-channel-binding-key.md
+++ b/.changeset/paid-write-btp-and-channel-binding-key.md
@@ -20,14 +20,28 @@ leg the x402 greeting bootstrap (connector #617) needs, and as the BTP
 transport's own fallback; an explicitly pinned `proxyUrl`/`btpUrl` is never
 overridden. Reads, fee estimates and the channel open are unchanged.
 
-When discovery names no BTP endpoint the fallback is a new
-`OFFICIAL_BTP_URL` — the RELAY box of the two-box devnet
-(`wss://proxy.relay.devnet.toonprotocol.dev/ilp/btp`, the publish route every
-push terminates at). Deliberately NOT `@toon-protocol/core`'s genesis seed,
-which still names the retired apex `proxy.devnet.toonprotocol.dev`: that host
-resolves but refuses connections since the two-box cutover, and the embedded
-client dials BTP during `start()`, so adopting it would turn a late 401 into
-rig refusing to run at all.
+**Both official default endpoints move off the retired apex.** The two-box
+cutover destroyed `proxy.devnet.toonprotocol.dev`; it still resolves but
+refuses connections, and rig's defaults both pointed at it:
+
+- `OFFICIAL_PROXY_URL` was `https://proxy.devnet.toonprotocol.dev/rust/ilp`
+  and is now `https://proxy.relay.devnet.toonprotocol.dev/ilp` — exactly what
+  the relay's own live kind:10032 announce advertises as its `httpEndpoint`.
+  The PATH moved too: `/rust/ilp` was a legacy path from when the Rust and TS
+  fleets ran side by side, and the live edge answers `410 Gone` on it while
+  serving the ingress at plain `/ilp`. This one is load-bearing beyond paid
+  writes — it is the endpoint the x402 greeting bootstrap dials, so a dead
+  value fails a FRESH channel open even when claims ride BTP.
+- `OFFICIAL_BTP_URL` is new: `wss://proxy.relay.devnet.toonprotocol.dev/ilp/btp`,
+  the fallback when discovery names no BTP endpoint. Deliberately NOT
+  `@toon-protocol/core`'s genesis seed, which still names the retired apex —
+  and because the embedded client dials BTP during `start()`, adopting a dead
+  endpoint would turn a late 401 into rig refusing to run at all.
+
+Both now sit on the relay box, which is the one that terminates
+`OFFICIAL_PUBLISH_DESTINATION` (`g.toon.relay`). After this change no rig
+default references the retired apex anywhere — a property the tests pin
+directly, so the next topology move fails loudly rather than silently.
 
 Because a derived endpoint is only a discovery guess, an unreachable one now
 DEGRADES instead of failing the run: a bootstrap failure classified as a BTP

--- a/.changeset/paid-write-btp-and-channel-binding-key.md
+++ b/.changeset/paid-write-btp-and-channel-binding-key.md
@@ -1,0 +1,46 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Fix two defects found by a live devnet run: every paid write 401'd, and each
+run risked leaking a fresh on-chain payment channel.
+
+**Paid writes could never reach BTP.** With no explicit entry, topology
+resolution placed the official proxy (ILP-over-HTTP) and nothing else, so the
+embedded client built no BTP session at all. The client's default transport
+precedence is HTTP-first, so every claim-bearing write went out as a
+`POST /ilp` one-shot carrying only an unauthenticated `ILP-Peer-Id` header —
+which the live edge answers `401 Unauthorized: identity 'g.toon.client'
+failed to authenticate`, failing `rig push --yes` before any object uploaded.
+Resolution now ALSO adopts the payment peer's announced `btpEndpoint`
+(genesis seed as the fallback) whenever no uplink was pinned explicitly, and
+the embedded client is built with `preferBtpForPaidWrites` (toon-client#482)
+so claims ride the BTP session, which authenticates on connect. The proxy
+stays in place as the HTTP leg the x402 greeting bootstrap (connector #617)
+needs, and as the BTP transport's own fallback; an explicitly pinned
+`proxyUrl`/`btpUrl` is never overridden. Reads, fee estimates and the channel
+open are unchanged.
+
+Note the client's own `requiredTransport` guard (toon-client#558) does not
+cover this case: not one live kind:10032 announce carries that field, so the
+guard never fires against the current fleet. `@toon-protocol/client` is bumped
+to `^0.29.7` for the #558/#563 guards regardless — they are the second line of
+defence once an announce does declare it, and #563's 402-driven retry needs a
+`btpUrl` to retry ONTO, which is exactly what this change supplies.
+
+**Leaked on-chain payment channels.** `ChannelManager.peerChannels` is keyed
+by the composite binding key `<peerId>|<chain>|<tokenNetwork>`
+(toon-client#489), not the bare peer id. Rig read that key back as if it WERE
+a peer id, so `peerNegotiations.get(...)` missed and a freshly opened channel
+was never recorded — rig warned `opened channel 0x… but could not record the
+peer→channel mapping` and the next invocation had nothing to resume. It also
+seeded resumed channels under the bare peer id, a key `ensureChannel` never
+looks up. Both sides now spell the binding key the way the client does (with
+pre-#489 bare keys still read correctly), so one channel serves every
+invocation. On a devnet where gas is the scarce resource, each duplicate open
+was a real cost. The unit mocks keyed `peerChannels` by the bare peer id too,
+which is why the suite stayed green through the regression; they now mirror
+the client's real key.
+
+The topology cache key gains a schema tag, so entries written before this
+change cannot shadow the new resolution for a TTL after upgrading.

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.29.0",
+    "@toon-protocol/client": "^0.29.7",
     "@toon-protocol/core": "^3.2.0",
     "nostr-tools": "^2.20.0"
   },

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -19,15 +19,20 @@ import {
 } from '../standalone/network-bootstrap.js';
 import { MinaZkAppStore } from '../standalone/mina-zkapp-store.js';
 import {
+  OFFICIAL_BTP_URL,
   OFFICIAL_PROXY_URL,
   OFFICIAL_PUBLISH_DESTINATION,
+  bootstrapRecoveries,
   buildMinaAutoDeploy,
+  isBtpTransportError,
   resolveNetworkTopology,
   resolveUplinkConfig,
   type ClientConfigFile,
   type GenesisSeedLike,
+  type NetworkTopology,
   type NetworkTopologyInputs,
 } from './standalone-mode.js';
+import type { StandalonePublisher } from '../standalone/standalone-publisher.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -143,7 +148,8 @@ describe('resolveNetworkTopology — uplink', () => {
       inputs({ announce: undefined, genesisSeed: undefined })
     );
     expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
-    expect(topology.btpUrl).toBeUndefined();
+    // Both legs are official constants — discovery only ever refines them.
+    expect(topology.btpUrl).toBe(OFFICIAL_BTP_URL);
   });
 });
 
@@ -177,29 +183,32 @@ describe('resolveNetworkTopology — paid-write BTP companion', () => {
     expect(topology.btpUrl).toBe('wss://proxy.devnet.toonprotocol.dev:443');
   });
 
-  it('falls back to the genesis seed when no announce is discovered', async () => {
+  it('falls back to the official relay BTP ingress, NOT the genesis seed', async () => {
+    // The committed seed in @toon-protocol/core still names the RETIRED apex
+    // (`proxy.devnet.toonprotocol.dev`), a host that resolves but refuses
+    // connections since the two-box cutover. Because the embedded client
+    // dials BTP during start(), adopting it would turn a late 401 into rig
+    // refusing to run at all.
     const topology = await resolveNetworkTopology(
       inputs({ announce: undefined })
     );
-    expect(topology.btpUrl).toBe(GENESIS.btpEndpoint);
+    expect(topology.btpUrl).toBe(OFFICIAL_BTP_URL);
+    expect(topology.btpUrl).not.toBe(GENESIS.btpEndpoint);
+    expect(OFFICIAL_BTP_URL).not.toContain('//proxy.devnet.');
   });
 
-  it('ignores an announce whose btpEndpoint is empty, using the seed', async () => {
+  it('ignores an announce whose btpEndpoint is empty', async () => {
     const topology = await resolveNetworkTopology(
       inputs({ announce: apexAnnounce({ btpEndpoint: '' }) })
     );
-    expect(topology.btpUrl).toBe(GENESIS.btpEndpoint);
+    expect(topology.btpUrl).toBe(OFFICIAL_BTP_URL);
   });
 
-  it('leaves the topology BTP-less when neither announce nor seed has one', async () => {
-    const topology = await resolveNetworkTopology(
-      inputs({
-        announce: apexAnnounce({ btpEndpoint: '' }),
-        genesisSeed: undefined,
-      })
-    );
-    expect(topology.btpUrl).toBeUndefined();
-    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+  it('marks a discovered endpoint as derived (droppable when unreachable)', async () => {
+    for (const announce of [apexAnnounce(), undefined]) {
+      const topology = await resolveNetworkTopology(inputs({ announce }));
+      expect(topology.btpUrlDerived).toBe(true);
+    }
   });
 
   // An operator who pinned an uplink pinned the transport with it — silently
@@ -212,12 +221,162 @@ describe('resolveNetworkTopology — paid-write BTP companion', () => {
     expect(topology.btpUrl).toBeUndefined();
   });
 
-  it('never overrides an explicitly pinned BTP uplink', async () => {
+  it('never overrides an explicitly pinned BTP uplink, and never marks it derived', async () => {
     const topology = await resolveNetworkTopology(
       inputs({ file: { btpUrl: 'wss://my-btp.example:443' } })
     );
     expect(topology.btpUrl).toBe('wss://my-btp.example:443');
     expect(topology.proxyUrl).toBeUndefined();
+    expect(topology.btpUrlDerived).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unreachable-BTP classification
+//
+// The gate on dropping a derived BTP leg. Narrow on purpose: it decides
+// whether rig may abandon a configured transport, so anything broader would
+// paper over unrelated bootstrap failures.
+// ---------------------------------------------------------------------------
+
+describe('isBtpTransportError', () => {
+  const named = (name: string, message = 'boom'): Error => {
+    const err = new Error(message);
+    err.name = name;
+    return err;
+  };
+
+  it('matches the client BTP socket/auth failures', () => {
+    // @toon-protocol/client throws these (unexported) for a websocket that
+    // would not open or would not authenticate.
+    expect(
+      isBtpTransportError(
+        named('BtpConnectionError', 'WebSocket connection error: ECONNREFUSED')
+      )
+    ).toBe(true);
+    expect(isBtpTransportError(named('BtpAuthError'))).toBe(true);
+  });
+
+  it('does NOT match unrelated bootstrap failures', () => {
+    expect(isBtpTransportError(named('Error', 'connect ECONNREFUSED'))).toBe(
+      false
+    );
+    expect(isBtpTransportError(named('ToonClientError'))).toBe(false);
+    expect(isBtpTransportError(named('ChannelMapCorruptError'))).toBe(false);
+    expect(isBtpTransportError(named('MinaFeePayerUnfundedError'))).toBe(false);
+    expect(isBtpTransportError('BtpConnectionError')).toBe(false);
+    expect(isBtpTransportError(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap recoveries
+//
+// The safety net behind the BTP companion: the embedded client dials BTP
+// during start(), so an unreachable DERIVED endpoint must degrade to HTTP
+// rather than stop rig from running — a strictly worse failure than the 401
+// it replaces.
+// ---------------------------------------------------------------------------
+
+describe('bootstrapRecoveries', () => {
+  const DERIVED: NetworkTopology = {
+    proxyUrl: OFFICIAL_PROXY_URL,
+    btpUrl: OFFICIAL_BTP_URL,
+    btpUrlDerived: true,
+    destination: 'g.toon.relay',
+    knownPeers: [],
+  };
+  const btpDown = (): Error => {
+    const err = new Error('WebSocket connection error: ECONNREFUSED');
+    err.name = 'BtpConnectionError';
+    return err;
+  };
+
+  /** Records every topology a rebuild built from. */
+  function harness(
+    topology: NetworkTopology,
+    reresolve?: () => Promise<NetworkTopology>
+  ) {
+    const built: NetworkTopology[] = [];
+    const recoveries = bootstrapRecoveries({
+      topology,
+      buildPublisher: (topo) => {
+        built.push(topo);
+        return {} as StandalonePublisher;
+      },
+      ...(reresolve ? { reresolve } : {}),
+    });
+    return { built, recoveries };
+  }
+
+  it('drops an unreachable DERIVED BTP leg, keeping the HTTP uplink', async () => {
+    const { built, recoveries } = harness(DERIVED);
+    const btp = recoveries.find((r) => r.applies(btpDown()));
+    expect(btp).toBeDefined();
+    await btp?.rebuild();
+    expect(built).toHaveLength(1);
+    expect(built[0]?.btpUrl).toBeUndefined();
+    expect(built[0]?.btpUrlDerived).toBeUndefined();
+    // Everything else survives — this degrades one transport, not the topology.
+    expect(built[0]?.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+    expect(built[0]?.destination).toBe('g.toon.relay');
+  });
+
+  it('names the dead endpoint and the remedy in the warning', () => {
+    const { recoveries } = harness(DERIVED);
+    const line = recoveries[recoveries.length - 1]?.describe(btpDown()) ?? '';
+    expect(line).toContain(OFFICIAL_BTP_URL);
+    expect(line).toContain('ECONNREFUSED');
+    expect(line).toContain('rig entry');
+  });
+
+  it('never drops an EXPLICITLY pinned BTP uplink', () => {
+    const { recoveries } = harness({
+      ...DERIVED,
+      btpUrl: 'wss://pinned.example:443',
+      btpUrlDerived: undefined,
+    });
+    expect(recoveries.some((r) => r.applies(btpDown()))).toBe(false);
+  });
+
+  it('does not fire for a non-BTP bootstrap failure', () => {
+    const { recoveries } = harness(DERIVED);
+    expect(
+      recoveries.some((r) => r.applies(new Error('chain misconfig')))
+    ).toBe(false);
+  });
+
+  it('registers no cache recovery for a live-resolved topology', () => {
+    const { recoveries } = harness(DERIVED);
+    expect(recoveries).toHaveLength(1);
+  });
+
+  // The two recoveries COMPOSE: the degrade must drop the BTP leg of whatever
+  // the cache recovery re-resolved, not of the topology it started from.
+  it('degrades the RE-RESOLVED topology after a cache recovery', async () => {
+    const fresh: NetworkTopology = {
+      ...DERIVED,
+      btpUrl: 'wss://rotated.example/ilp/btp',
+      destination: 'g.toon.relay',
+    };
+    const { built, recoveries } = harness(DERIVED, async () => fresh);
+    expect(recoveries).toHaveLength(2);
+
+    await recoveries[0]?.rebuild(); // cache miss → live re-resolve
+    expect(built[0]?.btpUrl).toBe('wss://rotated.example/ilp/btp');
+
+    expect(recoveries[1]?.applies(btpDown())).toBe(true);
+    expect(recoveries[1]?.describe(btpDown())).toContain(
+      'wss://rotated.example/ilp/btp'
+    );
+    await recoveries[1]?.rebuild();
+    expect(built[1]?.btpUrl).toBeUndefined();
+    expect(built[1]?.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+  });
+
+  it('the cache recovery applies to ANY failure (staleness is untypeable)', () => {
+    const { recoveries } = harness(DERIVED, async () => DERIVED);
+    expect(recoveries[0]?.applies(new Error('anything at all'))).toBe(true);
   });
 });
 

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -45,7 +45,14 @@ const MNEMONIC =
 const APEX_PUBKEY = 'a1'.repeat(32);
 const RELAY = 'wss://relay-ws.devnet.toonprotocol.dev';
 
-/** Live-devnet-shaped apex announce. */
+/**
+ * Live-devnet-shaped apex announce. Its endpoints deliberately sit on a
+ * DIFFERENT host from the `OFFICIAL_*` constants so precedence is provable
+ * either way — that the announce does not place the HTTP uplink, and that it
+ * DOES place the BTP one. Trusting a live announce over the baked constant is
+ * intentional: the announce is current where a constant is baked, and an
+ * unreachable announced endpoint is caught by the degrade recovery.
+ */
 function apexAnnounce(
   overrides: Partial<Record<string, unknown>> = {}
 ): AnnouncedPeer {
@@ -105,6 +112,48 @@ function inputs(
     ...overrides,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Official defaults
+//
+// The two baked-in endpoints rig falls back to. They are the ONLY network
+// addresses a default install dials, so they get pinned here: the two-box
+// cutover retired the apex, and a default still pointing at it fails a fresh
+// channel open (the x402 greeting) even when paid writes ride BTP.
+// ---------------------------------------------------------------------------
+
+describe('official default endpoints', () => {
+  /** The apex destroyed in the two-box cutover — resolves, refuses connections. */
+  const RETIRED_APEX_HOST = 'proxy.devnet.toonprotocol.dev';
+
+  it('no default references the retired apex', () => {
+    for (const url of [OFFICIAL_PROXY_URL, OFFICIAL_BTP_URL]) {
+      expect(new URL(url).hostname).not.toBe(RETIRED_APEX_HOST);
+    }
+  });
+
+  it('both defaults live on the relay box that serves the publish route', () => {
+    // OFFICIAL_PUBLISH_DESTINATION is `g.toon.relay`, so the uplink that
+    // terminates it must be the relay box — not the ario/store box.
+    expect(OFFICIAL_PUBLISH_DESTINATION).toBe('g.toon.relay');
+    for (const url of [OFFICIAL_PROXY_URL, OFFICIAL_BTP_URL]) {
+      expect(new URL(url).hostname).toBe('proxy.relay.devnet.toonprotocol.dev');
+    }
+  });
+
+  it('uses the live ingress paths, not the legacy apex ones', () => {
+    // The edge serves ILP-over-HTTP at plain `/ilp` (a GET answers `405
+    // allow: POST`) and answers `410 Gone` on the old `/rust/ilp`.
+    const proxy = new URL(OFFICIAL_PROXY_URL);
+    expect(proxy.protocol).toBe('https:');
+    expect(proxy.pathname).toBe('/ilp');
+    expect(OFFICIAL_PROXY_URL).not.toContain('/rust/');
+
+    const btp = new URL(OFFICIAL_BTP_URL);
+    expect(btp.protocol).toBe('wss:');
+    expect(btp.pathname).toBe('/ilp/btp');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Uplink resolution order

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -23,6 +23,7 @@ import {
   OFFICIAL_PUBLISH_DESTINATION,
   buildMinaAutoDeploy,
   resolveNetworkTopology,
+  resolveUplinkConfig,
   type ClientConfigFile,
   type GenesisSeedLike,
   type NetworkTopologyInputs,
@@ -113,7 +114,6 @@ describe('resolveNetworkTopology — uplink', () => {
   it('defaults the uplink to the official edge, announce or not', async () => {
     const topology = await resolveNetworkTopology(inputs());
     expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
-    expect(topology.btpUrl).toBeUndefined();
   });
 
   it('explicit env proxy beats the official default', async () => {
@@ -136,7 +136,6 @@ describe('resolveNetworkTopology — uplink', () => {
       inputs({ announce: apexAnnounce({ httpEndpoint: undefined }) })
     );
     expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
-    expect(topology.btpUrl).toBeUndefined();
   });
 
   it('needs neither an announce nor a genesis seed for an uplink', async () => {
@@ -144,6 +143,121 @@ describe('resolveNetworkTopology — uplink', () => {
       inputs({ announce: undefined, genesisSeed: undefined })
     );
     expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+    expect(topology.btpUrl).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paid-write BTP companion
+//
+// The proxy default alone leaves the embedded client with no BTP session, so
+// every paid write goes out as an unauthenticated `POST /ilp` — which the
+// live edge answers `401 Unauthorized: identity 'g.toon.client' failed to
+// authenticate`. NOTE the announces on the live fleet carry NO
+// `requiredTransport` field, so the client's own #558 guard never fires:
+// placing the endpoint (and preferring it, in createStandaloneContext) is
+// what actually gets a claim onto BTP.
+// ---------------------------------------------------------------------------
+
+describe('resolveNetworkTopology — paid-write BTP companion', () => {
+  it("adopts the announce's btpEndpoint alongside the official proxy", async () => {
+    const topology = await resolveNetworkTopology(inputs());
+    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+    expect(topology.btpUrl).toBe('wss://proxy.devnet.toonprotocol.dev:443');
+  });
+
+  it('does so even though the announce declares no requiredTransport', async () => {
+    // The live corpus: not one kind:10032 announce carries the field. The BTP
+    // endpoint must be adopted on its presence alone.
+    const announce = apexAnnounce();
+    expect(
+      (announce.info as unknown as Record<string, unknown>)['requiredTransport']
+    ).toBeUndefined();
+    const topology = await resolveNetworkTopology(inputs({ announce }));
+    expect(topology.btpUrl).toBe('wss://proxy.devnet.toonprotocol.dev:443');
+  });
+
+  it('falls back to the genesis seed when no announce is discovered', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ announce: undefined })
+    );
+    expect(topology.btpUrl).toBe(GENESIS.btpEndpoint);
+  });
+
+  it('ignores an announce whose btpEndpoint is empty, using the seed', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ announce: apexAnnounce({ btpEndpoint: '' }) })
+    );
+    expect(topology.btpUrl).toBe(GENESIS.btpEndpoint);
+  });
+
+  it('leaves the topology BTP-less when neither announce nor seed has one', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({
+        announce: apexAnnounce({ btpEndpoint: '' }),
+        genesisSeed: undefined,
+      })
+    );
+    expect(topology.btpUrl).toBeUndefined();
+    expect(topology.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+  });
+
+  // An operator who pinned an uplink pinned the transport with it — silently
+  // adding an announced BTP endpoint would route their paid writes off it.
+  it('never overrides an explicitly pinned proxy uplink', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ env: { TOON_CLIENT_PROXY_URL: 'https://my-proxy.example' } })
+    );
+    expect(topology.proxyUrl).toBe('https://my-proxy.example');
+    expect(topology.btpUrl).toBeUndefined();
+  });
+
+  it('never overrides an explicitly pinned BTP uplink', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ file: { btpUrl: 'wss://my-btp.example:443' } })
+    );
+    expect(topology.btpUrl).toBe('wss://my-btp.example:443');
+    expect(topology.proxyUrl).toBeUndefined();
+  });
+});
+
+describe('resolveUplinkConfig', () => {
+  it('prefers BTP for paid writes whenever a BTP uplink is available', () => {
+    expect(
+      resolveUplinkConfig({
+        proxyUrl: OFFICIAL_PROXY_URL,
+        btpUrl: 'wss://proxy.devnet.toonprotocol.dev/ilp/btp',
+      })
+    ).toEqual({
+      proxyUrl: OFFICIAL_PROXY_URL,
+      btpUrl: 'wss://proxy.devnet.toonprotocol.dev/ilp/btp',
+      btpAuthToken: '',
+      preferBtpForPaidWrites: true,
+    });
+  });
+
+  it('keeps the proxy as the HTTP leg the x402 greeting bootstrap needs', () => {
+    const config = resolveUplinkConfig({
+      proxyUrl: OFFICIAL_PROXY_URL,
+      btpUrl: 'wss://btp.example:443',
+    });
+    expect(config.proxyUrl).toBe(OFFICIAL_PROXY_URL);
+    expect(config.connectorUrl).toBeUndefined();
+  });
+
+  it('sets the flag on a BTP-only topology too (ordered claim dispatch)', () => {
+    const config = resolveUplinkConfig({ btpUrl: 'wss://btp.example:443' });
+    expect(config.preferBtpForPaidWrites).toBe(true);
+    // validateConfig demands one of connectorUrl/proxyUrl; the dummy is
+    // never dialled (the BTP session is the runtime transport).
+    expect(config.connectorUrl).toBe('http://127.0.0.1:1');
+    expect(config.proxyUrl).toBeUndefined();
+  });
+
+  it('leaves a proxy-only topology on its historical HTTP-first path', () => {
+    expect(
+      resolveUplinkConfig({ proxyUrl: 'https://my-proxy.example' })
+    ).toEqual({ proxyUrl: 'https://my-proxy.example' });
   });
 });
 

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -158,17 +158,31 @@ export interface ClientConfigFile {
 /** An identity was resolved, but there is no way to send paid writes. */
 /**
  * The official TOON relay implementation's client edge — the Rust connector
- * on the devnet apex (connector #616: the parallel-fleet comparison
- * concluded and the Rust fleet serves the protocol's own `g.toon`
- * namespace). This is rig's DEFAULT uplink: paid writes go here unless an
- * entry is explicitly configured (`rig entry <url>` / `rig entry sandbox` /
- * the TOON_CLIENT_* env overrides). The channel bootstrap needs no
- * announce: the edge's x402 greeting carries the channel-opening facts
- * (connector #617), which the embedded client synthesizes a negotiation
- * from.
+ * (connector #616: the parallel-fleet comparison concluded and the Rust
+ * fleet serves the protocol's own `g.toon` namespace). This is rig's DEFAULT
+ * HTTP uplink: paid writes go here unless an entry is explicitly configured
+ * (`rig entry <url>` / `rig entry sandbox` / the TOON_CLIENT_* env
+ * overrides). It is also the endpoint the channel bootstrap needs, since the
+ * x402 greeting carries the channel-opening facts (connector #617) the
+ * embedded client synthesizes a negotiation from — so a dead value here
+ * fails a FRESH channel open even when paid writes ride BTP.
+ *
+ * BOTH the host and the path moved in the two-box cutover, and the old value
+ * (`https://proxy.devnet.toonprotocol.dev/rust/ilp`) was dead on both counts:
+ *
+ *   - Host: the apex was RETIRED and destroyed. `proxy.devnet.toonprotocol.dev`
+ *     still resolves but refuses connections; the relay box
+ *     (`g.toon.relay`) is where the publish route now lives.
+ *   - Path: `/rust/ilp` was a legacy apex path from the period when the Rust
+ *     and TS fleets ran side by side. The live edge serves the ILP-over-HTTP
+ *     ingress at plain `/ilp` (a GET answers `405 allow: POST`), and answers
+ *     `410 Gone` on `/rust/ilp` — the retirement is explicit, not incidental.
+ *
+ * This value is exactly what the relay's own live kind:10032 announce
+ * advertises as its `httpEndpoint`, so discovery and this fallback agree.
  */
 export const OFFICIAL_PROXY_URL =
-  'https://proxy.devnet.toonprotocol.dev/rust/ilp';
+  'https://proxy.relay.devnet.toonprotocol.dev/ilp';
 /** The official relay-write route on that edge. */
 export const OFFICIAL_PUBLISH_DESTINATION = 'g.toon.relay';
 

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -172,6 +172,23 @@ export const OFFICIAL_PROXY_URL =
 /** The official relay-write route on that edge. */
 export const OFFICIAL_PUBLISH_DESTINATION = 'g.toon.relay';
 
+/**
+ * The BTP ingress paid writes ride when discovery does not name one — the
+ * RELAY box of the two-box devnet (ILP address `g.toon.relay`), which is the
+ * publish route every `rig push` terminates at.
+ *
+ * Deliberately NOT the genesis seed's `btpEndpoint`. `@toon-protocol/core`'s
+ * committed seed still names the retired apex
+ * (`wss://proxy.devnet.toonprotocol.dev/ilp/btp`), a host that resolves but
+ * refuses connections since the two-box cutover — and because the embedded
+ * client dials BTP during `start()`, handing it a dead endpoint would turn a
+ * late 401 into rig refusing to start at all. That is what
+ * {@link isBtpTransportError}'s degrade recovery guards against in general;
+ * this constant keeps the common path off the dead box in the first place.
+ */
+export const OFFICIAL_BTP_URL =
+  'wss://proxy.relay.devnet.toonprotocol.dev/ilp/btp';
+
 export class MissingUplinkError extends Error {
   constructor(configPath: string, relayUrl: string | undefined) {
     const discovered = relayUrl
@@ -252,6 +269,14 @@ export interface NetworkTopologyInputs {
 export interface NetworkTopology {
   proxyUrl?: string;
   btpUrl?: string;
+  /**
+   * True when `btpUrl` came from DISCOVERY (the announce, or the
+   * {@link OFFICIAL_BTP_URL} fallback) rather than explicit config. Only a
+   * derived endpoint may be dropped by the unreachable-BTP degrade recovery
+   * — an operator's explicit pin is never silently abandoned. Persisted with
+   * the rest of the topology in the #279 cache.
+   */
+  btpUrlDerived?: boolean;
   /** Channel anchor / default ILP destination. */
   destination: string;
   publishDestination?: string;
@@ -488,7 +513,8 @@ export async function resolveNetworkTopology(
   // identity 'g.toon.client' failed to authenticate`, because the HTTP
   // one-shot carries only an unauthenticated `ILP-Peer-Id` header while the
   // BTP session authenticates on connect. Adopting the payment peer's
-  // ANNOUNCED BTP endpoint (genesis seed as the fallback) gives the client
+  // ANNOUNCED BTP endpoint ({@link OFFICIAL_BTP_URL} as the fallback — NOT
+  // the genesis seed, which still names the retired apex) gives the client
   // both transports; `preferBtpForPaidWrites` (set alongside this in
   // `createStandaloneContext`) then sends claims over BTP first and keeps
   // HTTP as the transport's own fallback. The x402 greeting bootstrap
@@ -498,8 +524,15 @@ export async function resolveNetworkTopology(
   // Only when NO uplink was configured explicitly: someone who pinned
   // `TOON_CLIENT_PROXY_URL` / `proxyUrl` pinned the transport too, and a
   // silently-added announce endpoint would route their paid writes off it.
+  //
+  // A derived endpoint is marked as such: it is a DISCOVERY guess, and the
+  // client dials it during `start()`, so an unreachable one must be able to
+  // degrade back to HTTP rather than stop rig from running. An explicit
+  // `btpUrl` is an operator's pin and is never dropped behind their back.
+  let btpUrlDerived = false;
   if (!explicitProxyUrl && !explicitBtpUrl) {
-    btpUrl = announce?.info.btpEndpoint || genesisSeed?.btpEndpoint;
+    btpUrl = announce?.info.btpEndpoint || OFFICIAL_BTP_URL;
+    btpUrlDerived = true;
   }
 
   // ── Destination anchor + publish/store routes ────────────────────────────
@@ -823,7 +856,7 @@ export async function resolveNetworkTopology(
 
   return {
     ...(proxyUrl ? { proxyUrl } : {}),
-    ...(btpUrl ? { btpUrl } : {}),
+    ...(btpUrl ? { btpUrl, ...(btpUrlDerived ? { btpUrlDerived } : {}) } : {}),
     destination,
     ...(publishDestination ? { publishDestination } : {}),
     ...(storeDestination ? { storeDestination } : {}),
@@ -898,8 +931,98 @@ export function resolveUplinkConfig(
 }
 
 // ---------------------------------------------------------------------------
-// Cached-topology recovery (#279)
+// Bootstrap recovery (#279 cached topology; unreachable derived BTP uplink)
 // ---------------------------------------------------------------------------
+
+/**
+ * Whether a start failure came from the BTP uplink itself — the websocket
+ * would not open, or would not authenticate.
+ *
+ * `@toon-protocol/client` throws its own `BtpConnectionError`/`BtpAuthError`
+ * for exactly these, but does not export them, so (like the channel
+ * introspection in `../standalone/standalone-publisher.ts`) they are matched
+ * structurally by `name`. Matching narrowly is the point: this decides
+ * whether rig may drop the BTP leg, and a broad match would silently paper
+ * over unrelated bootstrap failures.
+ */
+export function isBtpTransportError(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : '';
+  return name === 'BtpConnectionError' || name === 'BtpAuthError';
+}
+
+/**
+ * One registered, single-use bootstrap recovery: whether it could address a
+ * given failure, what to tell the operator, and how to rebuild.
+ */
+export interface PublisherRecovery {
+  /** True when this recovery could plausibly address `err`. */
+  applies: (err: unknown) => boolean;
+  /** Warned before the retry — says what is being changed, and why. */
+  describe: (err: unknown) => string;
+  rebuild: () => Promise<StandalonePublisher>;
+}
+
+/**
+ * The bootstrap recoveries a standalone publisher runs with, in order (see
+ * {@link TopologyRecoveringPublisher} for the retry contract).
+ *
+ * The recoveries share one mutable "topology the inner publisher was built
+ * from", so they COMPOSE: the BTP degrade drops the BTP leg of whatever the
+ * cache recovery re-resolved, never of the topology this was called with.
+ *
+ * @param reresolve present only for a CACHE-sourced publisher (it should
+ *   invalidate the entry and resolve live); absent means no cache recovery.
+ */
+export function bootstrapRecoveries(args: {
+  topology: NetworkTopology;
+  buildPublisher: (topo: NetworkTopology) => StandalonePublisher;
+  reresolve?: () => Promise<NetworkTopology>;
+}): PublisherRecovery[] {
+  let active = args.topology;
+  const detail = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);
+  const recoveries: PublisherRecovery[] = [];
+
+  // #279: a cache-sourced publisher whose bootstrap fails invalidates the
+  // entry, re-resolves live (which re-writes the cache), and retries — so a
+  // rotated peer endpoint costs one failed attempt, not a broken TTL.
+  const reresolve = args.reresolve;
+  if (reresolve) {
+    recoveries.push({
+      applies: () => true,
+      describe: (err) =>
+        'rig: bootstrap with the cached network topology failed ' +
+        `(${detail(err)}) — invalidating the cache and re-resolving live`,
+      rebuild: async () => {
+        active = await reresolve();
+        return args.buildPublisher(active);
+      },
+    });
+  }
+
+  // A DERIVED BTP endpoint is a discovery guess, and the client dials it
+  // during start() — so an unreachable one must not stop rig from running.
+  // It drops back to the HTTP uplink, which is the behaviour placing the BTP
+  // leg otherwise replaces. Gated on {@link isBtpTransportError} so an
+  // unrelated bootstrap failure is never papered over, and on
+  // `btpUrlDerived` so an operator's explicit `btpUrl` pin is never
+  // abandoned behind their back.
+  recoveries.push({
+    applies: (err) => active.btpUrlDerived === true && isBtpTransportError(err),
+    describe: (err) =>
+      `rig: the discovered BTP uplink ${active.btpUrl} is unreachable ` +
+      `(${detail(err)}) — continuing over the HTTP uplink alone; paid ` +
+      'writes an edge accepts only over BTP will still fail, so pin a ' +
+      'reachable endpoint with `rig entry <url>` if they do',
+    rebuild: async () => {
+      const { btpUrl: _btpUrl, btpUrlDerived: _derived, ...http } = active;
+      active = http;
+      return args.buildPublisher(active);
+    },
+  });
+
+  return recoveries;
+}
 
 /** Structural check for a cached {@link NetworkTopology} document. */
 function isNetworkTopology(value: unknown): value is NetworkTopology {
@@ -924,27 +1047,40 @@ const NON_RECOVERABLE_START_ERRORS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Publisher wrapper implementing the #279 cache-invalidation contract: when
- * the inner publisher was built from a CACHED topology and its bootstrap
- * (`start`/`startClientOnly`) fails, the cache entry is invalidated, the
- * topology is re-resolved LIVE, a fresh publisher replaces the inner one,
- * and the operation proceeds — one retry, never more. Bootstrap failures
- * are pre-payment by construction (start() completes before any claim is
- * signed), so the retry can never double-pay. Publishers built from a live
- * resolution get no recovery hook and fail through unchanged.
+ * Publisher wrapper that retries a failed bootstrap (`start`/
+ * `startClientOnly`) against a repaired publisher. Each registered
+ * {@link PublisherRecovery} fires AT MOST ONCE, in order, and only when it
+ * `applies` to the failure, so the retry count is bounded by the number of
+ * recoveries — never a loop. Bootstrap failures are pre-payment by
+ * construction (start() completes before any claim is signed), so a retry
+ * can never double-pay. With no applicable recovery left, the failure passes
+ * straight through.
+ *
+ * Two recoveries are registered by {@link createStandaloneContext}:
+ *
+ *   - #279 cache invalidation: a publisher built from a CACHED topology
+ *     re-resolves LIVE, so a rotated peer endpoint costs one failed attempt
+ *     rather than a broken TTL.
+ *   - Unreachable DERIVED BTP uplink: discovery only guesses the peer's BTP
+ *     ingress, and the client dials it during `start()` — so a dead endpoint
+ *     would otherwise stop rig from running at all, which is strictly worse
+ *     than the HTTP-only behaviour it replaced. The BTP leg is dropped and
+ *     the run proceeds over HTTP. Never for an EXPLICIT `btpUrl`: that is an
+ *     operator's pin, and quietly abandoning it would hide a real
+ *     misconfiguration.
  */
 class TopologyRecoveringPublisher implements Publisher {
   private inner: StandalonePublisher;
-  private rebuild: (() => Promise<StandalonePublisher>) | undefined;
+  private readonly recoveries: PublisherRecovery[];
   private readonly warn: (line: string) => void;
 
   constructor(
     inner: StandalonePublisher,
-    rebuild: (() => Promise<StandalonePublisher>) | undefined,
+    recoveries: PublisherRecovery[],
     warn: (line: string) => void
   ) {
     this.inner = inner;
-    this.rebuild = rebuild;
+    this.recoveries = [...recoveries];
     this.warn = warn;
   }
 
@@ -957,36 +1093,39 @@ class TopologyRecoveringPublisher implements Publisher {
   }
 
   /**
-   * Run the bootstrap step, recovering ONCE from a stale cached topology.
-   * A rebuild failure surfaces the LIVE resolution's error — that is the
-   * network's real state, strictly more actionable than the cached failure.
+   * Run the bootstrap step, retrying against a repaired publisher for as long
+   * as an unused recovery applies. The LAST attempt's error is what surfaces
+   * — after a live re-resolution or an HTTP-only rebuild that is the
+   * network's real state, strictly more actionable than the failure that
+   * triggered the retry.
    */
   private async ensure(
     start: (p: StandalonePublisher) => Promise<void>
   ): Promise<StandalonePublisher> {
-    try {
-      await start(this.inner);
-      return this.inner;
-    } catch (err) {
-      const rebuild = this.rebuild;
-      this.rebuild = undefined;
-      const name = err instanceof Error ? err.name : '';
-      if (!rebuild || NON_RECOVERABLE_START_ERRORS.has(name)) throw err;
-      this.warn(
-        'rig: bootstrap with the cached network topology failed ' +
-          `(${err instanceof Error ? err.message : String(err)}) — ` +
-          'invalidating the cache and re-resolving live'
-      );
-      const fresh = await rebuild();
+    for (;;) {
       try {
-        // Failed starts release their own lock/state; stop() is idempotent.
-        await this.inner.stop();
-      } catch {
-        // best-effort teardown of the abandoned publisher
+        await start(this.inner);
+        return this.inner;
+      } catch (err) {
+        const name = err instanceof Error ? err.name : '';
+        if (NON_RECOVERABLE_START_ERRORS.has(name)) throw err;
+        // First applicable recovery wins, and is consumed either way — the
+        // loop is bounded by the number registered.
+        const index = this.recoveries.findIndex((r) => r.applies(err));
+        if (index < 0) throw err;
+        const [recovery] = this.recoveries.splice(index, 1) as [
+          PublisherRecovery,
+        ];
+        this.warn(recovery.describe(err));
+        const fresh = await recovery.rebuild();
+        try {
+          // Failed starts release their own lock/state; stop() is idempotent.
+          await this.inner.stop();
+        } catch {
+          // best-effort teardown of the abandoned publisher
+        }
+        this.inner = fresh;
       }
-      this.inner = fresh;
-      await start(this.inner);
-      return this.inner;
     }
   }
 
@@ -1359,17 +1498,22 @@ export async function createStandaloneContext(
     });
   };
 
-  // Cache-sourced publishers get the #279 recovery hook: a failed bootstrap
-  // invalidates the entry, re-resolves live (which re-writes the cache), and
-  // retries once. Live-resolved publishers fail through unchanged.
   const publisher = new TopologyRecoveringPublisher(
     buildPublisher(topology),
-    cached
-      ? async () => {
-          cache.invalidate(cacheKey);
-          return buildPublisher(await resolveLiveTopology());
-        }
-      : undefined,
+    bootstrapRecoveries({
+      topology,
+      buildPublisher,
+      // Only a CACHE-sourced publisher gets the re-resolve recovery;
+      // live-resolved ones have nothing staler to fall back from.
+      ...(cached
+        ? {
+            reresolve: async () => {
+              cache.invalidate(cacheKey);
+              return resolveLiveTopology();
+            },
+          }
+        : {}),
+    }),
     warn
   );
 

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -26,6 +26,12 @@
  * `../standalone/network-bootstrap.ts`. The pure resolution lives in
  * {@link resolveNetworkTopology} (unit-testable without any network).
  *
+ * PAID-WRITE TRANSPORT: with no explicit uplink, the resolution places BOTH
+ * the official proxy (ILP-over-HTTP, which the x402 greeting bootstrap needs)
+ * and the payment peer's announced BTP endpoint, and the embedded client is
+ * built with `preferBtpForPaidWrites` so claims ride the authenticated BTP
+ * session instead of an unauthenticated `POST /ilp` the edge answers 401.
+ *
  * TOPOLOGY CACHE (#279): the resolved topology is persisted under
  * `TOON_CLIENT_HOME` (`../standalone/topology-cache.ts`) keyed by
  * relay-origin + identity + an explicit-config fingerprint, with a 15-min
@@ -470,9 +476,30 @@ export async function resolveNetworkTopology(
   // overrides are for, and those are all EXPLICIT. `MissingUplinkError`
   // can no longer fire from here — an uplink always resolves.
   let proxyUrl = explicitProxyUrl;
-  const btpUrl = explicitBtpUrl;
+  let btpUrl = explicitBtpUrl;
   if (!proxyUrl && !btpUrl) {
     proxyUrl = OFFICIAL_PROXY_URL;
+  }
+
+  // ── Paid-write BTP companion ─────────────────────────────────────────────
+  // The proxy default above places an ILP-over-HTTP uplink and NOTHING else,
+  // so the embedded client builds no BTP session at all and every paid write
+  // goes out as `POST /ilp` — which the live edge answers `401 Unauthorized:
+  // identity 'g.toon.client' failed to authenticate`, because the HTTP
+  // one-shot carries only an unauthenticated `ILP-Peer-Id` header while the
+  // BTP session authenticates on connect. Adopting the payment peer's
+  // ANNOUNCED BTP endpoint (genesis seed as the fallback) gives the client
+  // both transports; `preferBtpForPaidWrites` (set alongside this in
+  // `createStandaloneContext`) then sends claims over BTP first and keeps
+  // HTTP as the transport's own fallback. The x402 greeting bootstrap
+  // (connector #617) still rides the proxy, so the channel-open path is
+  // unchanged.
+  //
+  // Only when NO uplink was configured explicitly: someone who pinned
+  // `TOON_CLIENT_PROXY_URL` / `proxyUrl` pinned the transport too, and a
+  // silently-added announce endpoint would route their paid writes off it.
+  if (!explicitProxyUrl && !explicitBtpUrl) {
+    btpUrl = announce?.info.btpEndpoint || genesisSeed?.btpEndpoint;
   }
 
   // ── Destination anchor + publish/store routes ────────────────────────────
@@ -815,6 +842,58 @@ export async function resolveNetworkTopology(
       : {}),
     ...(solanaChannel ? { solanaChannel } : {}),
     ...(minaChannel ? { minaChannel } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Embedded-client transport config
+// ---------------------------------------------------------------------------
+
+/** The transport slice of the embedded client's config. */
+export type UplinkConfig = Pick<
+  ToonClientConfig,
+  | 'proxyUrl'
+  | 'connectorUrl'
+  | 'btpUrl'
+  | 'btpAuthToken'
+  | 'preferBtpForPaidWrites'
+>;
+
+/**
+ * Turn a resolved topology's uplinks into the client's transport config.
+ *
+ * `preferBtpForPaidWrites` is the load-bearing part. The client's default
+ * precedence is HTTP-first, so a proxy-configured client sends every paid
+ * write as a `POST /ilp` one-shot carrying only an unauthenticated
+ * `ILP-Peer-Id` header — which the live edge answers `401 Unauthorized:
+ * identity 'g.toon.client' failed to authenticate`, making `rig push`
+ * impossible. The flag (toon-client#482) swaps the order so claims ride the
+ * BTP session, which authenticates on connect; the BTP transport keeps the
+ * HTTP one as its OWN fallback, so a proxy+BTP topology loses nothing when
+ * BTP is the broken side. Reads, the x402 greeting and the channel open are
+ * untouched either way.
+ *
+ * The client's `requiredTransport` guard (toon-client#558) does not cover
+ * this: no live kind:10032 announce carries that field, so the guard never
+ * fires against the current fleet.
+ */
+export function resolveUplinkConfig(
+  topo: Pick<NetworkTopology, 'proxyUrl' | 'btpUrl'>
+): UplinkConfig {
+  return {
+    // validateConfig requires connectorUrl OR proxyUrl; with BTP-only
+    // config a dummy connectorUrl satisfies it (unused at runtime — same
+    // convention as the daemon).
+    ...(topo.proxyUrl
+      ? { proxyUrl: topo.proxyUrl }
+      : { connectorUrl: 'http://127.0.0.1:1' }),
+    ...(topo.btpUrl
+      ? {
+          btpUrl: topo.btpUrl,
+          btpAuthToken: '',
+          preferBtpForPaidWrites: true,
+        }
+      : {}),
   };
 }
 
@@ -1167,12 +1246,7 @@ export async function createStandaloneContext(
 
   const buildPublisher = (topo: NetworkTopology): StandalonePublisher => {
     const clientConfig: ToonClientConfig = {
-      // validateConfig requires connectorUrl OR proxyUrl; with BTP-only
-      // config a dummy connectorUrl satisfies it (unused at runtime — same
-      // convention as the daemon).
-      ...(topo.proxyUrl
-        ? { proxyUrl: topo.proxyUrl }
-        : { connectorUrl: 'http://127.0.0.1:1' }),
+      ...resolveUplinkConfig(topo),
       mnemonic: identity.mnemonic,
       mnemonicAccountIndex: identity.accountIndex,
       ilpInfo: {
@@ -1184,7 +1258,6 @@ export async function createStandaloneContext(
       },
       toonEncoder: encodeEventToToon,
       toonDecoder: decodeEventFromToon,
-      ...(topo.btpUrl ? { btpUrl: topo.btpUrl, btpAuthToken: '' } : {}),
       destinationAddress: topo.destination,
       // The embedded client bootstraps against the known peer above; its
       // `relayUrl` config only seeds ArDrive-merged peers, so it stays unset.

--- a/packages/rig/src/standalone/standalone-publisher.test.ts
+++ b/packages/rig/src/standalone/standalone-publisher.test.ts
@@ -702,6 +702,13 @@ describe('StandalonePublisher', () => {
       tokenNetwork: '0x' + '22'.repeat(20),
     };
 
+    /** `ChannelManager.bindingKey` — the key `peerChannels` really uses. */
+    const bindingKey = (
+      peerId: string,
+      negotiation: typeof NEGOTIATION
+    ): string =>
+      `${peerId}|${negotiation.chain}|${negotiation.tokenNetwork ?? ''}`;
+
     interface ChannelMockCalls extends MockCalls {
       onChainOpens: number;
       trackChannel: { channelId: string; context: PersistedChannelContext }[];
@@ -743,11 +750,22 @@ describe('StandalonePublisher', () => {
         },
         async openChannel(destination?: string) {
           calls.openChannel.push(destination);
-          const existing = peerChannels.get(PEER_ID);
+          // Mirrors ChannelManager.ensureChannel: `peerChannels` is keyed by
+          // the COMPOSITE binding key `<peerId>|<chain>|<tokenNetwork>`
+          // (toon-client#489), never the bare peer id. Spelling it the way
+          // the real client does is load-bearing — a bare-peer-id mock hides
+          // both halves of the leak (a resume seed ensureChannel never finds,
+          // and a recorded "peer id" that is really a whole binding key).
+          const [peerId, negotiation] = [...peerNegotiations.entries()][0] ?? [
+            PEER_ID,
+            NEGOTIATION,
+          ];
+          const key = bindingKey(peerId, negotiation);
+          const existing = peerChannels.get(key);
           if (existing) return existing; // ensureChannel: reuse, no on-chain
           calls.onChainOpens += 1;
           const channelId = `0xchannel-${calls.onChainOpens}`;
-          peerChannels.set(PEER_ID, channelId);
+          peerChannels.set(key, channelId);
           return channelId;
         },
         async signBalanceProof(channelId: string, amount: bigint) {
@@ -822,6 +840,45 @@ describe('StandalonePublisher', () => {
         cumulativeAmount: '0',
       });
       expect(warnings).toEqual([]);
+    });
+
+    // Regression: `peerChannels` is keyed by `<peerId>|<chain>|<tokenNetwork>`
+    // (toon-client#489). Reading that key back as if it were a peer id made
+    // `peerNegotiations.get(...)` miss, so a fresh open was NEVER recorded —
+    // rig warned "could not record the peer→channel mapping" and the next
+    // invocation had nothing to resume, leaking an on-chain channel (and the
+    // gas to open it) per `rig push`.
+    it('records the BARE peer id even though peerChannels is keyed by the composite binding key', async () => {
+      const { client } = mockChannelClient();
+      const publisher = buildPersistent(client);
+      await publisher.publishEvent(EVENT, []);
+      await publisher.stop();
+
+      expect(map.list()[0]?.peerId).toBe(PEER_ID);
+      expect(warnings.join('\n')).not.toMatch(/could not record/);
+    });
+
+    // The other half of the same mismatch: a resume seeded under the bare peer
+    // id is invisible to `ensureChannel`, which opens a second channel anyway.
+    it('seeds a resumed channel under the composite binding key', async () => {
+      const { client: clientA } = mockChannelClient();
+      const runA = buildPersistent(clientA);
+      await runA.publishEvent(EVENT, []);
+      await runA.stop();
+
+      const { client: clientB } = mockChannelClient();
+      const runB = buildPersistent(clientB);
+      await runB.publishEvent(EVENT, []);
+      await runB.stop();
+
+      const peerChannels = (
+        clientB as unknown as {
+          channelManager: { peerChannels: Map<string, string> };
+        }
+      ).channelManager.peerChannels;
+      expect([...peerChannels.keys()]).toEqual([
+        bindingKey(PEER_ID, NEGOTIATION),
+      ]);
     });
 
     it('REUSES the channel across invocations: second run resumes, zero on-chain opens', async () => {
@@ -980,8 +1037,8 @@ describe('StandalonePublisher', () => {
       const { client: clientB, calls: callsB } = mockChannelClient({
         negotiations: rotated,
       });
-      // Process B's openChannel keys peerChannels by PEER_ID, so a resume
-      // seed for the OLD peer id must not be found: assert no resume happened.
+      // The recorded peer is no longer negotiated, so the resume candidate is
+      // skipped outright: assert no resume happened.
       const runB = buildPersistent(clientB);
       await runB.publishEvent(EVENT, []);
       await runB.stop();

--- a/packages/rig/src/standalone/standalone-publisher.ts
+++ b/packages/rig/src/standalone/standalone-publisher.ts
@@ -320,6 +320,33 @@ interface ChannelInternals {
   };
 }
 
+/**
+ * The key `ChannelManager` binds a peer's channel under —
+ * `<peerId>|<chain>|<tokenNetwork>` (toon-client#489: the same peer on a
+ * second chain, or a redeployed token network, is a DIFFERENT channel).
+ * `peerChannels` used to be keyed by the bare peer id, so rig both wrote
+ * resumed channels under a key `ensureChannel` never looks up (a fresh
+ * on-chain channel per invocation) and read the composite key back as if it
+ * were a peer id (so `peerNegotiations.get(...)` missed and nothing was ever
+ * recorded). Keep in sync with `@toon-protocol/client`'s
+ * `ChannelManager.bindingKey`.
+ */
+function channelBindingKey(
+  peerId: string,
+  chain: string,
+  tokenNetwork: string
+): string {
+  return `${peerId}|${chain}|${tokenNetwork}`;
+}
+
+/**
+ * The peer id inside a {@link channelBindingKey}. A pre-#489 bare-peer-id key
+ * has no separator and passes through unchanged, so this reads either shape.
+ */
+function peerIdFromBindingKey(key: string): string {
+  return key.split('|')[0] ?? key;
+}
+
 /** Best-effort access to the client's private negotiation/channel state. */
 function channelInternals(client: ToonClientLike): ChannelInternals {
   const c = client as unknown as ChannelInternals;
@@ -630,9 +657,13 @@ export class StandalonePublisher implements Publisher {
       }
 
       // trackChannel rehydrates nonce/cumulative from the watermark store;
-      // seeding peerChannels makes ensureChannel/openChannel reuse the id.
+      // seeding peerChannels makes ensureChannel/openChannel reuse the id —
+      // but ONLY under the composite binding key it looks up.
       cm.trackChannel(record.channelId, record.context);
-      cm.peerChannels.set(record.peerId, record.channelId);
+      cm.peerChannels.set(
+        channelBindingKey(record.peerId, record.chain, record.tokenNetwork),
+        record.channelId
+      );
 
       // Persisted channel state omits the on-chain deposit — re-read it so
       // fee/balance accounting is right (EVM only; mirrors the daemon).
@@ -679,11 +710,13 @@ export class StandalonePublisher implements Publisher {
     destination: string,
     channelId: string
   ): void {
+    // `peerChannels` is keyed by the COMPOSITE binding key, not the peer id
+    // (toon-client#489) — read the peer id back out of it.
     let peerId: string | undefined;
-    for (const [peer, channel] of internals.channelManager?.peerChannels ??
+    for (const [key, channel] of internals.channelManager?.peerChannels ??
       []) {
       if (channel === channelId) {
-        peerId = peer;
+        peerId = peerIdFromBindingKey(key);
         break;
       }
     }
@@ -818,7 +851,10 @@ export class StandalonePublisher implements Publisher {
     const cm = internals.channelManager;
     if (cm?.trackChannel && cm.peerChannels) {
       cm.trackChannel(record.channelId, record.context);
-      cm.peerChannels.set(record.peerId, record.channelId);
+      cm.peerChannels.set(
+        channelBindingKey(record.peerId, record.chain, record.tokenNetwork),
+        record.channelId
+      );
     }
     const contextCache = internals.onChainChannelClient?.channelContext;
     if (contextCache && !contextCache.has(record.channelId)) {

--- a/packages/rig/src/standalone/topology-cache.test.ts
+++ b/packages/rig/src/standalone/topology-cache.test.ts
@@ -11,11 +11,13 @@ import {
   writeFileSync,
   existsSync,
 } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_TOPOLOGY_TTL_MS,
+  TOPOLOGY_SCHEMA_VERSION,
   TOPOLOGY_TTL_ENV,
   TopologyCache,
   explicitConfigFingerprint,
@@ -70,6 +72,17 @@ describe('topologyCacheKey / explicitConfigFingerprint', () => {
       key
     );
     expect(topologyCacheKey({ ...base, fingerprint: '{"a":1}' })).not.toBe(key);
+  });
+
+  // A release that changes WHAT resolution produces for the same inputs (the
+  // BTP companion uplink) must not be shadowed by the previous release's
+  // entries for a whole TTL — the schema tag is what makes those miss.
+  it('is namespaced by the schema version', () => {
+    expect(TOPOLOGY_SCHEMA_VERSION).toBeGreaterThan(1);
+    const legacy = createHash('sha256')
+      .update(`${base.relayUrl}\n${base.identity}\n${base.fingerprint}`)
+      .digest('hex');
+    expect(topologyCacheKey(base)).not.toBe(legacy);
   });
 
   it('fingerprints every explicit topology input (env + file), nothing else', () => {

--- a/packages/rig/src/standalone/topology-cache.ts
+++ b/packages/rig/src/standalone/topology-cache.ts
@@ -50,9 +50,20 @@ export function topologyCacheTtlMs(env: NodeJS.ProcessEnv): number {
 }
 
 /**
- * Stable cache key: relay-origin + identity pubkey + the explicit-config
- * fingerprint. Hashed so the key is filename/JSON-safe and the mnemonic-side
- * inputs never appear in the cache file verbatim.
+ * Schema tag mixed into every cache key. A rig release that changes WHAT the
+ * resolution produces for the same inputs (not just its values) must bump
+ * this: entries written by the previous release then miss instead of
+ * shadowing the new behaviour for a whole TTL. Bumped to 2 when the default
+ * resolution started placing a BTP uplink alongside the proxy — a cached
+ * v1 topology has no `btpUrl`, so paid writes would have kept 401ing for 15
+ * minutes after the upgrade.
+ */
+export const TOPOLOGY_SCHEMA_VERSION = 2;
+
+/**
+ * Stable cache key: schema tag + relay-origin + identity pubkey + the
+ * explicit-config fingerprint. Hashed so the key is filename/JSON-safe and
+ * the mnemonic-side inputs never appear in the cache file verbatim.
  */
 export function topologyCacheKey(args: {
   relayUrl: string;
@@ -60,7 +71,10 @@ export function topologyCacheKey(args: {
   fingerprint: string;
 }): string {
   return createHash('sha256')
-    .update(`${args.relayUrl}\n${args.identity}\n${args.fingerprint}`)
+    .update(
+      `v${TOPOLOGY_SCHEMA_VERSION}\n${args.relayUrl}\n${args.identity}\n` +
+        args.fingerprint
+    )
     .digest('hex');
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.29.0
-        version: 0.29.0(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.29.7
+        version: 0.29.7(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^3.2.0
         version: 3.2.0(typescript@5.9.3)
@@ -8367,8 +8367,8 @@ packages:
       - zod
     dev: true
 
-  /@toon-protocol/client@0.29.0(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-98zydohZcCAv2w7yoAoWwBHtd6+3Un3f5pXZI26I7YfakOKqi4qXaKZdmBejiOZ+7mpaPhKG6RIprKEqqafxAw==}
+  /@toon-protocol/client@0.29.7(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-boI9yU7gKLgH0CeLuNy6CIsZKd7or4n4uuvTaATOpSONh45kil6LWUURANkNSSHE43YJgV/W0A6vNW+7CTVmQw==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0
@@ -8376,8 +8376,8 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      '@toon-protocol/core': 3.2.0(typescript@5.9.3)
-      '@toon-protocol/sdk': 3.1.3(mina-signer@3.1.0)(typescript@5.9.3)
+      '@toon-protocol/core': 3.3.0(typescript@5.9.3)
+      '@toon-protocol/sdk': 3.1.7(mina-signer@3.1.0)(typescript@5.9.3)
       nostr-tools: 2.24.1(typescript@5.9.3)
       viem: 2.55.5(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
@@ -8682,69 +8682,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@toon-protocol/core@3.1.3(typescript@5.9.3):
-    resolution: {integrity: sha512-qN+RXHwriLXDl67hjBWiWXo49aqLBBtOnuh+aykpjKDyuMe26cKEHraV7ydiSpHFefgzA/yOAmuKl+ArmKcpZw==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      '@toon-protocol/connector': '>=3.3.3'
-    peerDependenciesMeta:
-      '@toon-protocol/connector':
-        optional: true
-    dependencies:
-      '@ardrive/turbo-sdk': 1.42.0(typescript@5.9.3)
-      '@noble/hashes': 2.2.0
-      '@scure/bip32': 2.2.0
-      '@scure/bip39': 2.2.0
-      '@toon-format/toon': 1.4.0
-      '@toon-protocol/settlement-digest': 1.0.0
-      arweave: 1.15.7
-      nostr-tools: 2.24.1(typescript@5.9.3)
-      simple-git: 3.36.0
-      ws: 8.21.2
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@x402/core'
-      - '@x402/evm'
-      - '@x402/extensions'
-      - '@x402/svm'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - preact-render-to-string
-      - react
-      - react-native
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-    dev: false
-
   /@toon-protocol/core@3.2.0(@types/react@19.2.17)(react@19.2.8)(typescript@5.9.3):
     resolution: {integrity: sha512-mNl4Oje+vz7g+C4nIHGRxB/W8/ySsFnaMN8kJkUsZ1muMgzl0srIskaauedWn4oMSC7pn1DXM7KVi9f0JW1yMw==}
     engines: {node: '>=22'}
@@ -8827,6 +8764,69 @@ packages:
       nostr-tools: 2.24.1(typescript@5.9.3)
       simple-git: 3.36.0
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - preact-render-to-string
+      - react
+      - react-native
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+    dev: false
+
+  /@toon-protocol/core@3.3.0(typescript@5.9.3):
+    resolution: {integrity: sha512-X/snuKfBIpX83qMngtuns883iqIyJ6No5RXf3zGxrggoqyYxLQ8tCjjen4BPKWLvnw1KPrKSXdSZjvqyaJ1oyw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@toon-protocol/connector': '>=3.3.3'
+    peerDependenciesMeta:
+      '@toon-protocol/connector':
+        optional: true
+    dependencies:
+      '@ardrive/turbo-sdk': 1.42.0(typescript@5.9.3)
+      '@noble/hashes': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      '@toon-format/toon': 1.4.0
+      '@toon-protocol/settlement-digest': 1.0.0
+      arweave: 1.15.7
+      nostr-tools: 2.24.1(typescript@5.9.3)
+      simple-git: 3.36.0
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9087,8 +9087,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@toon-protocol/sdk@3.1.3(mina-signer@3.1.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-QD9nh7t2X7H6T7N8X0fSCWhFoz6ljz2o98+iega5wQMziPSdMh90gcaeS8Z2dxYljfr2v2WG95j0gBW7qHIOOA==}
+  /@toon-protocol/sdk@3.1.7(mina-signer@3.1.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-88bFFaan2eV3YzE1bkoA8PzZseVENYXcuMb7iGGmQkKQMrsraqgUx22gONz2BZh6jkUbYgne21YZi044HAP0NA==}
     engines: {node: '>=22'}
     peerDependencies:
       '@toon-protocol/connector': '>=3.3.3'
@@ -9104,7 +9104,7 @@ packages:
       '@noble/hashes': 2.2.0
       '@scure/bip32': 2.2.0
       '@scure/bip39': 2.2.0
-      '@toon-protocol/core': 3.1.3(typescript@5.9.3)
+      '@toon-protocol/core': 3.3.0(typescript@5.9.3)
       '@toon-protocol/settlement-digest': 1.0.0
       mina-signer: 3.1.0
       nostr-tools: 2.24.1(typescript@5.9.3)


### PR DESCRIPTION
Two defects found by a live run against the TOON devnet on 2026-08-14, plus the endpoint/degradation hardening that fell out of review.

> **Property worth re-checking whenever the topology moves: after this PR no rig default references the retired apex anywhere.** Both `OFFICIAL_PROXY_URL` and `OFFICIAL_BTP_URL` sit on `proxy.relay.devnet.toonprotocol.dev`, and a test pins that directly (`official default endpoints › no default references the retired apex`), so the next move fails loudly instead of silently.

## 1 — `rig push` can never reach BTP, so every paid push 401s

`rig push --yes` against the live devnet relay failed on the first git-object upload:

```
[Bootstrap] Announce failed for nostr-30fdd01d55c3efeb:
  ILP-over-HTTP request rejected (401 Unauthorized): identity 'g.toon.client' failed to authenticate
    at HttpIlpClient.mapResponse (…/@toon-protocol/client/dist/index.js)
    at async StandalonePublisher.uploadGitObject (…/rig/dist/chunk-…js)
rig push failed: Failed to publish event
```

With no explicit entry, `resolveNetworkTopology` placed the official proxy (`OFFICIAL_PROXY_URL`, ILP-over-HTTP) **and nothing else** — the live announce's `btpEndpoint` was only ever used to name a bootstrap peer. So the embedded client built no BTP session at all, and the client's default transport precedence is HTTP-first: every claim-bearing write went out as a `POST /ilp` one-shot carrying only an unauthenticated `ILP-Peer-Id` header, which the edge rejects. The BTP session authenticates on connect, which is why the same publish over the same channel succeeds over BTP.

**Fix.** Resolution now also adopts the payment peer's announced `btpEndpoint` whenever no uplink was pinned explicitly, and the embedded client is built with `preferBtpForPaidWrites` (toon-client#482), so claims take BTP first. The proxy stays in place — it is the HTTP leg the x402 greeting bootstrap (connector #617) needs for the channel open, and it remains the BTP transport's own fallback. An explicitly pinned `TOON_CLIENT_PROXY_URL`/`proxyUrl`/`btpUrl` is never overridden: pinning an uplink pins the transport with it.

### The fallback endpoint, and degrading instead of refusing

The first push of this branch used the genesis seed as the BTP fallback. That was wrong and would have been a live blocker — `@toon-protocol/core`'s committed seed still names the **retired apex**. Verified independently this session:

| host | DNS | `GET /ilp` | `GET /ilp/btp` |
|---|---|---|---|
| `proxy.devnet.toonprotocol.dev` (genesis seed / retired apex) | 104.237.150.177 | `000` conn refused | `000` conn refused |
| `proxy.relay.devnet.toonprotocol.dev` (`g.toon.relay`) | 97.107.134.182 | `405` | `400` |
| `proxy.ario.devnet.toonprotocol.dev` (`g.toon.ario`) | 45.79.173.113 | `405` | `400` |

Since the embedded client dials BTP inside `start()`, handing it a dead endpoint converts a late 401 into rig **not starting at all** — strictly worse than the bug being fixed. Three changes:

- New `OFFICIAL_BTP_URL = wss://proxy.relay.devnet.toonprotocol.dev/ilp/btp` — the relay box, which is the publish route every `rig push` terminates at. The genesis seed is no longer consulted for a BTP endpoint at all.
- **`OFFICIAL_PROXY_URL` moves to `https://proxy.relay.devnet.toonprotocol.dev/ilp`** (was `https://proxy.devnet.toonprotocol.dev/rust/ilp`) — the value the relay's own live kind:10032 announce advertises as its `httpEndpoint`. Both the host **and the path** moved: `/rust/ilp` was a legacy path from when the Rust and TS fleets ran side by side, and the live edge answers `410 Gone` on it while serving the ingress at plain `/ilp`. This one is load-bearing beyond paid writes — it is the endpoint the x402 greeting bootstrap (connector #617) dials, so a dead value fails a **fresh channel open** even when claims ride BTP.
- `NetworkTopology.btpUrlDerived` marks a discovery-sourced endpoint, and a new bootstrap recovery **drops the BTP leg and retries over HTTP** when `start()` fails with a BTP socket/auth error. Gated by `isBtpTransportError`, which matches the client's own (unexported) `BtpConnectionError`/`BtpAuthError` by `name` — narrow on purpose, so an unrelated bootstrap failure is never papered over. Never applied to an explicit `btpUrl` pin: that is an operator's choice, and quietly abandoning it would hide a real misconfiguration.

This reuses the existing #279 cached-topology retry seam, now a bounded ordered chain of single-use recoveries (`bootstrapRecoveries`). The two compose: the BTP degrade drops the BTP leg of whatever the cache recovery re-resolved, not of the original topology. Bootstrap failures are pre-payment by construction, so no retry can double-pay.

### On the client version

`@toon-protocol/client` goes `^0.29.0 → ^0.29.7`, which brings the toon-client#558 `terminatorRequiresBtp` guard (absent from 0.29.0) and #563's 402-driven BTP retry. **Neither rescues this case on its own:**

- #558 reads `requiredTransport` off the terminating announce, and **zero live kind:10032 announces carry that field** — the guard never fires against the current fleet.
- #563 retries onto the BTP uplink after a `402`, but the observed failure is a `401`, and it needs a `btpUrl` to retry *onto*, which is exactly what was missing. It now has one.

`preferBtpForPaidWrites: true` is the mechanism that actually works today and depends on neither. **Follow-up bump wanted, not blocking:** toon-client `main` has since merged #569 (`Http401RequiresBtpError` — a 401→BTP retry, precisely this failure) and has #571 open (stop sending the unbacked `ILP-Peer-Id`, so the 401 never happens rather than being recovered from). Neither is published to npm, so this PR deliberately does not pin to them. Once a release carries both, rig could return `preferBtpForPaidWrites` to an opt-in and let HTTP-first stand, since the 401 would either not occur or self-recover — the BTP companion endpoint and the degrade recovery would still be wanted.

## 2 — rig leaks on-chain payment channels

The same run printed:

```
rig: opened channel 0x413d0c87… but could not record the peer→channel mapping
(client does not expose negotiation internals) — the NEXT invocation may open another channel
```

Root cause: `ChannelManager.peerChannels` is keyed by the **composite binding key** `<peerId>|<chain>|<tokenNetwork>` since toon-client#489, not by the bare peer id. Rig reaches into that map (the documented structural-cast pattern it shares with the MCP daemon) in two places, and both assumed the old shape:

- `recordOpenedChannel` reverse-looks-up the channel id and used the map **key** as the peer id, so `peerNegotiations.get(...)` missed → warning, nothing recorded, next invocation has nothing to resume.
- `resumeRecordedChannel` / `adoptRecordedChannel` seeded the resumed channel under the **bare peer id**, a key `ensureChannel` never looks up.

Both now spell the key the way the client does, via a `channelBindingKey` helper documented as keep-in-sync with `ChannelManager.bindingKey` (pre-#489 bare keys are still read correctly). **No client API addition is required** — everything rig needs is already reachable, it was simply spelled wrong.

The unit mocks keyed `peerChannels` by the bare peer id too, which is why the suite stayed green straight through the regression. They now mirror the real client's key; reverting the source fix turns **14** tests red (re-confirmed after the rebase), including pre-existing channel-reuse tests that were previously passing vacuously.

## Also

The topology cache key gains a schema tag (`TOPOLOGY_SCHEMA_VERSION`), so entries written before this change cannot shadow the new resolution for a 15-minute TTL after upgrading.

## Tests

- `standalone-mode.test.ts` — the BTP companion matrix, explicitly including the **live reality** that the announce carries no `requiredTransport`; announce > `OFFICIAL_BTP_URL` fallback with an assertion that it is *not* the genesis seed's retired-apex host; `btpUrlDerived` marking; both "never override an explicit pin" cases. Plus `resolveUplinkConfig` (the transport slice extracted from `buildPublisher` so the flag is directly testable), `isBtpTransportError` (matches the two BTP error names, rejects six unrelated ones), and `bootstrapRecoveries` (degrade keeps the HTTP leg and the rest of the topology; never fires for an explicit pin or a non-BTP failure; composes correctly after a cache re-resolve).
- `standalone-publisher.test.ts` — two named regressions for each half of the binding-key mismatch, plus the mock corrected to the real key shape.
- `standalone-mode.test.ts` (`official default endpoints`) — pins both baked-in endpoints: neither is on the retired-apex host, both are on the relay box that terminates `g.toon.relay`, and the paths are the live `/ilp` + `/ilp/btp` rather than the legacy `/rust/ilp`. Reverting `OFFICIAL_PROXY_URL` to its old value turns 3 tests red.
- `topology-cache.test.ts` — the key is namespaced by the schema version.

## Gate (re-run on `5825949`, atop `ff6335a`)

| step | result |
|---|---|
| `pnpm -r build` | pass |
| `pnpm typecheck` | pass |
| `.sandcastle/gate/*.test.ts` | 22/22 |
| `.sandcastle/gate/correctness.ts` | `eslint 0e/220w, typecheck 0e` — exactly at the frozen baseline |
| `pnpm -r test` | 1023 + 357 passing |

`pnpm format:check` fails identically before and after (130 pre-existing files, and CI does not run it); files this branch touched are prettier-clean.

## Not verified here

Both fixes are verified by unit tests, by reading the installed client, and (for the endpoints) by read-only HTTPS probes — this branch touches no live boxes. The proven-good configuration was `preferBtpForPaidWrites` with `proxyUrl` omitted; this change keeps `proxyUrl` alongside the BTP uplink so the channel-open path is untouched, which is the lower-risk shape but is one step away from what was proven end-to-end. A live re-run is planned as a separate verification pass.

`OFFICIAL_PROXY_URL` was raised as out-of-scope in review and then pulled IN, because it would have blocked the live verification run: the x402 greeting bootstrap dials it, so a fresh channel open on a default config fails even with claims riding BTP. It moved from `https://proxy.devnet.toonprotocol.dev/rust/ilp` to `https://proxy.relay.devnet.toonprotocol.dev/ilp` — see the section above. Strictly the constant: no `EXPECTED_CONNECTOR_TAG`, fleet image pin, or `infra/` overlay is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
