### PR TITLE
rig push cannot pay a store node that holds its own channel

### DIFF
--- a/.changeset/print-all-arweave-gateways.md
+++ b/.changeset/print-all-arweave-gateways.md
@@ -1,0 +1,23 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Print every Arweave gateway from the shared list, and take the default from it
+
+The Rig-page link is the one URL a user clicks after a push, and it was
+hardcoded to `ar-io.dev` with a single printed alternate. A gateway can be
+flat DOWN rather than merely behind: observed 2026-08-15, `ar-io.dev`
+answered `503` on its own root while a freshly pushed page was `404` on
+`arweave.net` (not yet indexed) and `200` on `permagate.io` — so the single
+alternate was also dead and the reader was left with no working link and the
+impression the push had failed.
+
+`rig push` now prints every gateway in `ARWEAVE_GATEWAYS` from the shared
+`@toon-protocol/arweave` package, and both `rig push` and `rig site` take
+their default primary from the head of that list instead of repeating a
+literal, so the one list stays the single source of truth. The wording no
+longer blames indexing speed alone — it says a gateway can be down, because
+that is the case that sends someone hunting a publish bug that isn't there.
+
+`RIG_ARWEAVE_GATEWAY` / `--gateway` still override, and an overridden primary
+is never repeated among its own alternates.

--- a/.changeset/require-client-0-29-8.md
+++ b/.changeset/require-client-0-29-8.md
@@ -1,0 +1,14 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Require `@toon-protocol/client` >= 0.29.8
+
+The store leg cannot open a channel against the store node's own settlement
+address without the per-destination counterparty resolution that shipped in
+client 0.29.8 (toon-client#571). On 0.29.7 `openChannel` still falls back to
+the first negotiated peer, so the store connector refuses every git-object
+upload with `F01 - claim rejected: names a channel this connector has no
+record of`. Verified directly: the same rig build fails on 0.29.7 and
+succeeds on 0.29.8. The floor is raised rather than left at `^0.29.7`,
+because this is a hard requirement, not a preference.

--- a/.changeset/store-leg-own-uplink.md
+++ b/.changeset/store-leg-own-uplink.md
@@ -1,0 +1,32 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Pay store writes on the store node's own channel
+
+On a fleet where the store route terminates on a different node than
+publishes, `rig push` signed the git-object claim on the PUBLISH channel and
+sent it to the store node, which refuses it outright — `F01 - claim rejected:
+names a channel this connector has no record of`. There is no transit to lean
+on either: the publish node's only route is its own publish prefix, so the
+store has to be reached directly.
+
+The store leg now gets its own uplink, resolved from the store node's own
+kind:10032 announce (each node publishes only its own BTP ingress), its own
+payment channel against that node's settlement address, and its own watermark
+file — two live clients pointed at one channel store clobber each other's
+watermarks. It is built lazily on the first store write, so a publish-only run
+opens no second on-chain channel.
+
+Two supporting fixes fell out of it:
+
+- Route prices are now read from `routePrices`, the shape the live connector
+  actually publishes, in addition to the older `capabilities` array — and from
+  the announce of whichever node terminates the address, since each node
+  prices its own routes. Without this the upload fee floored at 0 and the
+  store answered `F03 - claim rejected: advances value by 0, less than this
+  route's price`.
+- A config pinning a store route on a different node is no longer treated as
+  "fully explicit" unless it also pins that node's uplink (`storeBtpUrl` /
+  `TOON_CLIENT_STORE_BTP_URL`). It previously skipped discovery entirely and
+  so never learned the store endpoint.

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toon-protocol/rig",
   "version": "3.5.3",
-  "description": "Git-to-TOON write path core — build git objects and NIP-34 events for the Rig control plane",
+  "description": "Git-to-TOON write path core \u2014 build git objects and NIP-34 events for the Rig control plane",
   "license": "MIT",
   "author": "Jonathan Green",
   "repository": {
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^1.0.0",
-    "@toon-protocol/client": "^0.29.7",
+    "@toon-protocol/client": "^0.29.8",
     "@toon-protocol/core": "^3.2.0",
     "nostr-tools": "^2.20.0"
   },

--- a/packages/rig/src/cli/push.test.ts
+++ b/packages/rig/src/cli/push.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ARWEAVE_GATEWAYS } from '@toon-protocol/arweave';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -665,6 +666,59 @@ describe('standalone push (Publisher seam)', () => {
     expect(text).toContain('RIG_MNEMONIC environment variable');
     expect(text).toContain('.env');
     expect(text).toContain(join(homeDir, 'config.json'));
+  });
+
+
+  // ---------------------------------------------------------------------------
+  // Printed gateway addresses
+  //
+  // The Rig-page link is the one URL a user actually clicks after a push, and a
+  // gateway can be flat DOWN rather than merely behind: on 2026-08-15
+  // `ar-io.dev` answered 503 on its own root while the page was live and
+  // byte-identical on the other two. Printing a single alternate is one outage
+  // away from leaving the reader with no working link and the impression the
+  // push failed — so every gateway in the SHARED list is printed, and the list
+  // is the single source of truth rather than a literal repeated per call site.
+  // ---------------------------------------------------------------------------
+
+  describe('rig page — printed gateway addresses', () => {
+    it('prints every gateway in the shared list, primary first', async () => {
+      const fake = makeStandalone(emptyRemoteState(), { withBlobUpload: true });
+      const h = makeDeps(env, repoDir, { loadStandalone: fake.load });
+      expect(await runPush(['--yes'], h.deps)).toBe(0);
+      const out = h.out.join('\n');
+
+      // Primary is the head of the shared list, not a literal.
+      expect(out).toContain(`Rig page: ${ARWEAVE_GATEWAYS[0]}/`);
+      // and EVERY other gateway is offered as a fallback.
+      for (const gateway of ARWEAVE_GATEWAYS.slice(1)) {
+        expect(out).toContain(`${gateway}/`);
+      }
+    });
+
+    it('tells the reader a gateway can be down, not just lagging', async () => {
+      // The old copy blamed indexing speed only, which sends someone hunting a
+      // publish bug when the gateway is simply returning 503.
+      const fake = makeStandalone(emptyRemoteState(), { withBlobUpload: true });
+      const h = makeDeps(env, repoDir, { loadStandalone: fake.load });
+      expect(await runPush(['--yes'], h.deps)).toBe(0);
+      expect(h.out.join('\n')).toMatch(/can be down/);
+    });
+
+    it('honours RIG_ARWEAVE_GATEWAY as the primary and never lists it twice', async () => {
+      const pinned = ARWEAVE_GATEWAYS[1] ?? 'https://arweave.net';
+      const fake = makeStandalone(emptyRemoteState(), { withBlobUpload: true });
+      const h = makeDeps(
+        { ...env, RIG_ARWEAVE_GATEWAY: pinned },
+        repoDir,
+        { loadStandalone: fake.load }
+      );
+      expect(await runPush(['--yes'], h.deps)).toBe(0);
+      const out = h.out.join('\n');
+      expect(out).toContain(`Rig page: ${pinned}/`);
+      // The pinned primary must not also appear among its own alternates.
+      expect(out.split(`${pinned}/`).length - 1).toBe(1);
+    });
   });
 });
 

--- a/packages/rig/src/cli/push.ts
+++ b/packages/rig/src/cli/push.ts
@@ -395,32 +395,34 @@ export interface RigPageReport {
 }
 
 /**
- * Gateway for printed Rig-page URLs. Must be a gateway that serves the
- * store's FRESH uploads — `ar-io.dev` (the head of the fetch-redundancy
- * list): the store currently uploads to the ar.io testnet, which
- * `arweave.net` (mainnet) never serves, and even for mainnet uploads it
- * lags until the bundle settles. The mirror URL printed alongside covers
- * the other gateway. Distinct from the BUNDLE gateway embedded in the
- * pointer HTML ({@link DEFAULT_RIG_WEB_GATEWAY}), which tracks where the
- * rig-web deploy lives. `RIG_ARWEAVE_GATEWAY` overrides, same as
- * `rig site`.
+ * Gateway for printed Rig-page URLs — the head of the SHARED fetch-redundancy
+ * list ({@link ARWEAVE_GATEWAYS}), not a literal, so rig prints whatever the
+ * one gateway list says is preferred and cannot drift from it.
+ *
+ * It must be a gateway that serves the store's FRESH uploads: the store
+ * currently uploads to the ar.io testnet, which `arweave.net` (mainnet) never
+ * serves, and even for mainnet uploads it lags until the bundle settles.
+ * Distinct from the BUNDLE gateway embedded in the pointer HTML
+ * ({@link DEFAULT_RIG_WEB_GATEWAY}), which tracks where the rig-web deploy
+ * lives. `RIG_ARWEAVE_GATEWAY` overrides, same as `rig site`.
  */
 function pointerGateway(env: NodeJS.ProcessEnv): string {
-  return (env['RIG_ARWEAVE_GATEWAY'] ?? 'https://ar-io.dev').replace(
-    /\/+$/,
-    ''
-  );
+  const preferred = ARWEAVE_GATEWAYS[0] ?? 'https://arweave.net';
+  return (env['RIG_ARWEAVE_GATEWAY'] ?? preferred).replace(/\/+$/, '');
 }
 
 /**
- * A second gateway to print alongside the primary pointer URL. Gateways
- * index fresh uploads at different speeds (arweave.net serves Turbo
- * uploads immediately; ar-io.dev can lag until the bundle is unbundled —
- * and vice versa for older data), so printing two addresses gives the
- * user a working link whichever side is behind.
+ * Every OTHER gateway from the shared list, printed under the primary.
+ *
+ * All of them, not just one: a gateway can be flat DOWN, not merely behind.
+ * Observed 2026-08-15 — `ar-io.dev` answered `503` on its own root while the
+ * page was live and byte-identical on both other gateways, and a single
+ * printed alternate is one outage away from leaving the reader with no
+ * working link and the impression their push failed. The count follows the
+ * shared list, so adding a gateway there adds it here.
  */
-function mirrorGateway(primary: string): string | undefined {
-  return ARWEAVE_GATEWAYS.find((g) => g !== primary);
+function mirrorGateways(primary: string): string[] {
+  return ARWEAVE_GATEWAYS.filter((g) => g.replace(/\/+$/, '') !== primary);
 }
 
 /** Build the Rig-pointer plan: deterministic pointer + content-addressed skip. */
@@ -729,11 +731,17 @@ export async function runPush(args: string[], deps: PushDeps): Promise<number> {
               : '') +
             '  (renders this repo from Arweave)'
         );
-        const mirror = rigPage.txId ? mirrorGateway(gateway) : undefined;
-        if (mirror) {
+        const mirrors = rigPage.txId ? mirrorGateways(gateway) : [];
+        if (mirrors.length > 0 && rigPage.txId) {
+          const txId = rigPage.txId;
           io.out(
-            `     also: ${mirror}/${rigPage.txId}  (same page; gateways index fresh uploads at different speeds)`
+            '     also: (same page — try these if the address above does ' +
+              'not load; gateways index fresh uploads at different speeds, ' +
+              'and any one of them can be down)'
           );
+          for (const mirror of mirrors) {
+            io.out(`           ${mirror}/${txId}`);
+          }
         }
       } else if (rigPage.detail) {
         io.err(`rig page: ${rigPage.detail}`);

--- a/packages/rig/src/cli/site.ts
+++ b/packages/rig/src/cli/site.ts
@@ -26,6 +26,7 @@
  * start, no relay query, no payment.
  */
 
+import { ARWEAVE_GATEWAYS } from '@toon-protocol/arweave';
 import { parseArgs } from 'node:util';
 import {
   buildArweaveManifest,
@@ -52,11 +53,17 @@ import type { StandaloneContext } from './standalone-context.js';
 export const MANIFEST_CONTENT_TYPE = 'application/x.arweave-manifest+json';
 
 /**
- * Default Arweave/ar.io gateway the printed site URL uses. `ar-io.dev`
- * because it serves the store's fresh uploads (currently ar.io testnet,
- * which mainnet `arweave.net` never indexes).
+ * Default Arweave/ar.io gateway the printed site URL uses: the head of the
+ * SHARED fetch-redundancy list ({@link ARWEAVE_GATEWAYS}) rather than a
+ * literal, so this and `rig push` cannot drift apart and adding a gateway to
+ * the one list moves both.
+ *
+ * The head must serve the store's fresh uploads (currently ar.io testnet,
+ * which mainnet `arweave.net` never indexes). A site is ONE manifest txid, so
+ * only the primary is printed here — pass `--gateway` (or
+ * `RIG_ARWEAVE_GATEWAY`) to re-print against another when one is down.
  */
-export const DEFAULT_GATEWAY = 'https://ar-io.dev';
+export const DEFAULT_GATEWAY = ARWEAVE_GATEWAYS[0] ?? 'https://arweave.net';
 
 export const SITE_USAGE = `Usage: rig site <publish|url> [ref] [options]
 

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -1278,3 +1278,91 @@ describe('buildMinaAutoDeploy — zkApp key persistence', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Store leg
+//
+// The store route can terminate on a DIFFERENT node than publishes, and that
+// node holds its own payment channel. A claim signed on the publish channel
+// is refused by it outright (`F01 - claim rejected: names a channel this
+// connector has no record of`), which is what made every `rig push` fail on
+// the two-box fleet: rig had one uplink and paid the store from the publish
+// channel. Each node also prices its OWN routes, so the store price has to be
+// read from the store node's announce, not the payment peer's — reading the
+// wrong one leaves the fee at 0 and the connector answers `F03 - claim
+// rejected: advances value by 0, less than this route's price`.
+// ---------------------------------------------------------------------------
+
+function storeAnnounce(
+  overrides: Partial<Record<string, unknown>> = {}
+): AnnouncedPeer {
+  const content: Record<string, unknown> = {
+    ilpAddress: 'g.proxy.store',
+    btpEndpoint: 'wss://store.example.test/ilp/btp',
+    assetCode: 'USDC',
+    assetScale: 6,
+    routePrices: { 'g.proxy.store': '1000' },
+    ...overrides,
+  };
+  return {
+    pubkey: 'ab'.repeat(32),
+    info: content as unknown as AnnouncedPeer['info'],
+    routes: { publish: 'g.proxy.store', store: 'g.proxy.store' },
+    ...(content['routePrices']
+      ? { routePrices: content['routePrices'] as Record<string, string> }
+      : {}),
+    createdAt: 1001,
+  };
+}
+
+describe('resolveNetworkTopology — store leg', () => {
+  it('takes the store uplink from the STORE node announce, not the payment peer', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ peers: [apexAnnounce(), storeAnnounce()] })
+    );
+    expect(topology.storeDestination).toBe('g.proxy.store');
+    expect(topology.storeBtpUrl).toBe('wss://store.example.test/ilp/btp');
+    // Never the payment peer's own endpoint — that is the publish leg's.
+    expect(topology.storeBtpUrl).not.toBe(topology.btpUrl);
+  });
+
+  it('prices the store route from the store node announce', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({ peers: [apexAnnounce(), storeAnnounce()] })
+    );
+    // Without this the upload fee floors at 0 and the store answers F03.
+    expect(topology.routePrices?.store).toBe('1000');
+  });
+
+  it('resolves no store uplink when the store terminates on the publish node', async () => {
+    // Single-box: one node, one channel — a second uplink would open a
+    // redundant on-chain channel against the same counterparty.
+    const announce = apexAnnounce();
+    announce.routes = { publish: 'g.proxy.relay', store: 'g.proxy.relay' };
+    const topology = await resolveNetworkTopology(
+      inputs({ announce, peers: [announce] })
+    );
+    expect(topology.storeBtpUrl).toBeUndefined();
+  });
+
+  it('never guesses a store uplink when no announce claims the route', async () => {
+    // A guessed store endpoint would send real claims to a node nobody
+    // advertised. Undiscovered stays undiscovered.
+    const warnings: string[] = [];
+    const topology = await resolveNetworkTopology(
+      inputs({ peers: [apexAnnounce()], warn: (l) => warnings.push(l) })
+    );
+    expect(topology.storeBtpUrl).toBeUndefined();
+    expect(warnings.join('\n')).toContain('g.proxy.store');
+  });
+
+  it('lets an explicit pin override the announced store uplink', async () => {
+    const topology = await resolveNetworkTopology(
+      inputs({
+        peers: [apexAnnounce(), storeAnnounce()],
+        file: { storeBtpUrl: 'wss://pinned.example.test/ilp/btp' },
+      })
+    );
+    expect(topology.storeBtpUrl).toBe('wss://pinned.example.test/ilp/btp');
+  });
+});

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -142,6 +142,13 @@ export interface ClientConfigFile {
   destination?: string;
   publishDestination?: string;
   storeDestination?: string;
+  /**
+   * BTP ingress of the node terminating `storeDestination`, when that is a
+   * different node than publishes go to. Normally discovered from that
+   * node's own kind:10032 announce; pin it here (or via
+   * `TOON_CLIENT_STORE_BTP_URL`) to skip discovery entirely.
+   */
+  storeBtpUrl?: string;
   feePerEvent?: string;
   channelStorePath?: string;
   /** Settlement chain: family (`evm`) or full id (`evm:31337`). */
@@ -255,6 +262,17 @@ export interface NetworkTopologyInputs {
   relayUrl: string;
   /** The discovered payment-peer announce, if any. */
   announce: AnnouncedPeer | undefined;
+  /**
+   * Every announce discovery returned, not just the picked payment peer.
+   * The store node announces itself SEPARATELY from the publish node (on
+   * this fleet, `g.toon.ario` alongside `g.toon.relay`), and its own
+   * `btpEndpoint` is the only place its BTP ingress is published — the
+   * payment peer's announce names the store ROUTE but not how to reach it.
+   * Optional so existing callers (and every test that builds inputs by
+   * hand) keep working: absent means "no store uplink discovered", which
+   * degrades to the single-uplink behaviour that predates this field.
+   */
+  peers?: AnnouncedPeer[];
   /** The committed genesis seed entry, if any. */
   genesisSeed: GenesisSeedLike | undefined;
   identity: { mnemonic: string; accountIndex: number; pubkey: string };
@@ -295,6 +313,23 @@ export interface NetworkTopology {
   destination: string;
   publishDestination?: string;
   storeDestination?: string;
+  /**
+   * BTP ingress of the node that TERMINATES {@link storeDestination}, when
+   * that is a different node from the publish peer.
+   *
+   * A payment-channel claim is only verifiable by the connector that holds
+   * the channel: the claim names a channel id, and a connector with no
+   * record of it refuses the packet outright (`F01 - claim rejected: names
+   * a channel this connector has no record of`). On the two-box fleet the
+   * store lives on its own node with its own settlement address, and the
+   * publish node has NO route to it — its only route is its own publish
+   * prefix — so a store write cannot be carried by the publish session and
+   * has to reach the store node directly, on its own channel.
+   *
+   * Absent when the store terminates on the same node as publishes (the
+   * single-box case), which needs no second uplink.
+   */
+  storeBtpUrl?: string;
   /** The peer the embedded client bootstraps + negotiates with. */
   knownPeers: { pubkey: string; relayUrl: string; btpEndpoint: string }[];
   /**
@@ -567,6 +602,36 @@ export async function resolveNetworkTopology(
       : undefined);
   const storeDestination = explicitStore ?? announce?.routes?.store;
 
+  // ── Store uplink ─────────────────────────────────────────────────────────
+  // Resolved from the STORE node's own announce, matched by the ilpAddress it
+  // publishes for itself — not from the payment peer's, which names the store
+  // route but carries no way to reach it. Only when the store terminates
+  // somewhere other than the publish peer: same-node stores ride the session
+  // that is already open, and handing them a second identical uplink would
+  // open a redundant on-chain channel against the same counterparty.
+  //
+  // No baked fallback here on purpose. `OFFICIAL_BTP_URL` can name the
+  // publish edge because that is where an unconfigured rig must end up
+  // anyway, but guessing a STORE endpoint would send claims — real money —
+  // to a node nobody advertised. Undiscovered means undiscovered.
+  const explicitStoreBtpUrl =
+    env['TOON_CLIENT_STORE_BTP_URL'] ?? file.storeBtpUrl;
+  let storeBtpUrl: string | undefined;
+  if (storeDestination && storeDestination !== publishDestination) {
+    const storePeer = inputs.peers?.find(
+      (peer) => peer.info.ilpAddress === storeDestination
+    );
+    storeBtpUrl = explicitStoreBtpUrl || storePeer?.info.btpEndpoint || undefined;
+    if (!storeBtpUrl && inputs.peers?.length) {
+      warn(
+        `rig: no announce found for the store route "${storeDestination}" — ` +
+          'store writes (git objects, the rig page) will be attempted on the ' +
+          'publish uplink and the terminating connector will refuse them if ' +
+          'it does not hold that channel'
+      );
+    }
+  }
+
   // ── Route-price floors ───────────────────────────────────────────────────
   // The announce's `capabilities` carry a FLAT price per destination route,
   // and the connector gates every paid packet at it (a claim advancing the
@@ -576,11 +641,21 @@ export async function resolveNetworkTopology(
   // exactly when a paid write would actually target the priced route. An
   // unmatched destination gets no floor (behavior unchanged).
   let routePrices: NetworkTopology['routePrices'];
-  const capabilities = announce?.capabilities;
-  if (capabilities && capabilities.length > 0) {
+  {
     const derived = deriveRouteDestinations(destination);
-    const priceOf = (address: string): string | undefined =>
-      capabilities.find((c) => c.address === address)?.price;
+    // Each node prices its OWN routes, so a price is looked up in the
+    // announce of whichever peer terminates that address — the store route's
+    // price lives in the store node's announce, not the payment peer's.
+    // Falls back to the payment peer for addresses no discovered peer claims,
+    // which is the single-node case and the pre-discovery behaviour.
+    const priceOf = (address: string): string | undefined => {
+      const owner =
+        inputs.peers?.find((p) => p.info.ilpAddress === address) ?? announce;
+      return (
+        owner?.routePrices?.[address] ??
+        owner?.capabilities?.find((c) => c.address === address)?.price
+      );
+    };
     const publishPrice = priceOf(publishDestination ?? derived.publish);
     const storePrice = priceOf(storeDestination ?? derived.store);
     if (publishPrice !== undefined || storePrice !== undefined) {
@@ -874,6 +949,8 @@ export async function resolveNetworkTopology(
     destination,
     ...(publishDestination ? { publishDestination } : {}),
     ...(storeDestination ? { storeDestination } : {}),
+    ...(storeBtpUrl ? { storeBtpUrl } : {}),
+
     ...(routePrices ? { routePrices } : {}),
     knownPeers,
     ...(selection ? { selection } : {}),
@@ -1271,6 +1348,12 @@ export async function createStandaloneContext(
 
   // ── Peer→channel persistence (#262) ──────────────────────────────────────
   const channelStorePath = file.channelStorePath ?? join(dir, 'channels.json');
+  // Sibling watermark file for the store leg's client — see the
+  // `channelStorePath` note where the store client config is built.
+  const storeChannelStorePath = channelStorePath.replace(
+    /(\.json)?$/,
+    '.store.json'
+  );
   const channelMap = new ChannelMapStore({
     mapPath: join(dir, RIG_CHANNEL_MAP_FILENAME),
     watermarkPath: channelStorePath,
@@ -1324,6 +1407,20 @@ export async function createStandaloneContext(
     const minaExplicitlyComplete = (file.supportedChains ?? []).every(
       (chain) => !chain.startsWith('mina:') || Boolean(file.minaChannel)
     );
+    // A config that pins a store route on a DIFFERENT node than it publishes
+    // to is not fully explicit unless it also pins that node's uplink. The
+    // store node holds its own channel, and a claim signed on the publish
+    // channel is refused by it (F01) — so without a store uplink the store
+    // route is unreachable, and only its own announce publishes one. Pinning
+    // the publish transport says nothing about how to reach the store.
+    const explicitStoreDest =
+      env['TOON_CLIENT_STORE_DESTINATION'] ?? file.storeDestination;
+    const explicitPublishDest =
+      env['TOON_CLIENT_PUBLISH_DESTINATION'] ?? file.publishDestination;
+    const storeUplinkKnown =
+      !explicitStoreDest ||
+      explicitStoreDest === explicitPublishDest ||
+      Boolean(env['TOON_CLIENT_STORE_BTP_URL'] ?? file.storeBtpUrl);
     const fullyExplicit =
       Boolean(
         (env['TOON_CLIENT_PROXY_URL'] ?? file.proxyUrl) ||
@@ -1331,14 +1428,19 @@ export async function createStandaloneContext(
       ) &&
       Boolean(env['TOON_CLIENT_DESTINATION'] ?? file.destination) &&
       Boolean(file.supportedChains?.length) &&
+      storeUplinkKnown &&
       solanaExplicitlyComplete &&
       minaExplicitlyComplete;
     let announce: AnnouncedPeer | undefined;
+    // Retained beyond the pick: the store node announces itself
+    // separately, and only its own announce carries its BTP ingress.
+    let discoveredPeers: AnnouncedPeer[] | undefined;
     if (!fullyExplicit) {
       try {
         const peers = await discoverAnnouncedPeers(relayUrl, {
           timeoutMs: DISCOVERY_TIMEOUT_MS,
         });
+        discoveredPeers = peers;
         const seedPubkeys = genesisSeedPubkeys();
         announce = pickPaymentPeer(peers, seedPubkeys);
         if (!announce) {
@@ -1367,6 +1469,7 @@ export async function createStandaloneContext(
       configPath,
       relayUrl,
       announce,
+      ...(discoveredPeers ? { peers: discoveredPeers } : {}),
       genesisSeed,
       identity: {
         mnemonic: identity.mnemonic,
@@ -1461,8 +1564,39 @@ export async function createStandaloneContext(
           : {}),
     };
 
+    // Store leg (#96 follow-up): when the store route terminates on its own
+    // node, it needs its own uplink and its own channel — a claim signed on
+    // the publish channel is refused by the store connector, which has no
+    // record of it (F01). Same identity and same channel store; only the
+    // transport and the destination differ, so the two legs stay one wallet.
+    const storeClientConfig: ToonClientConfig | undefined = topo.storeBtpUrl
+      ? {
+          ...clientConfig,
+          proxyUrl: undefined,
+          connectorUrl: 'http://127.0.0.1:1',
+          btpUrl: topo.storeBtpUrl,
+          btpAuthToken: '',
+          preferBtpForPaidWrites: true,
+          // Its OWN watermark file. A client's channel store and its
+          // `.peers.json` binding sidecar are one unit that the client
+          // rewrites wholesale, so pointing two live clients at one path has
+          // them clobber each other's watermarks — observed as the publish
+          // leg losing its channel ("is not being tracked", then F01) the
+          // moment the store leg opened. Separate files; the legs stay
+          // correlated through rig's own channel map, which is keyed by
+          // anchor and records both.
+          channelStorePath: storeChannelStorePath,
+          ilpInfo: {
+            ...clientConfig.ilpInfo,
+            btpEndpoint: topo.storeBtpUrl,
+          },
+          destinationAddress: topo.storeDestination ?? topo.destination,
+        }
+      : undefined;
+
     return new StandalonePublisher({
       clientConfig,
+      ...(storeClientConfig ? { storeClientConfig } : {}),
       eventFee,
       channelMap,
       warn,

--- a/packages/rig/src/standalone/network-bootstrap.ts
+++ b/packages/rig/src/standalone/network-bootstrap.ts
@@ -108,6 +108,13 @@ export interface AnnouncedPeer {
   /** Out-of-band `capabilities` content field (route prices), when valid. */
   capabilities?: AnnouncedCapability[];
   /**
+   * Out-of-band `routePrices` map (ILP address → base-unit price string) —
+   * the shape the live connector publishes, alongside/instead of
+   * `capabilities`. Each node prices its OWN routes, so the store route's
+   * price comes from the store node's announce, not the payment peer's.
+   */
+  routePrices?: Record<string, string>;
+  /**
    * Out-of-band `minaTokenIds` content field: chain id → Mina token id
    * (decimal string). The zkApp address for a Mina channel already rides the
    * standard `tokenNetworks` map (mirroring Solana's program id), but the Mina
@@ -188,6 +195,42 @@ function parseRoutes(content: string): AnnouncedRoutes | undefined {
       ...(typeof store === 'string' && store.length > 0 ? { store } : {}),
     };
     return out.publish || out.store ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parse the announce's `routePrices` map (ILP address → base-unit price
+ * string), the shape the live connector actually publishes.
+ *
+ * This is a SEPARATE surface from `capabilities`, not a rename of it: the
+ * connector emits `routePrices` on every kind:10032 while `capabilities` is
+ * the older, richer array carrying a capability name alongside the price.
+ * A fleet publishing only `routePrices` left the price floor unset, which
+ * the store route surfaces as `F03 - claim rejected: advances value by 0,
+ * less than this route's price` — the floor exists precisely so a
+ * bytes-derived fee that rounds to nothing is lifted to what the route
+ * charges. Values are validated like every other announced amount.
+ */
+function parseRoutePrices(
+  content: string
+): Record<string, string> | undefined {
+  try {
+    const parsed = JSON.parse(content) as { routePrices?: unknown };
+    const raw = parsed.routePrices;
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      return undefined;
+    }
+    const out: Record<string, string> = {};
+    for (const [address, price] of Object.entries(
+      raw as Record<string, unknown>
+    )) {
+      if (address.length > 0 && typeof price === 'string' && /^\d+$/.test(price)) {
+        out[address] = price;
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
   } catch {
     return undefined;
   }
@@ -316,6 +359,7 @@ export async function discoverAnnouncedPeers(
     }
     const routes = parseRoutes(event.content);
     const capabilities = parseCapabilities(event.content);
+    const routePrices = parseRoutePrices(event.content);
     const minaTokenIds = parseMinaTokenIds(event.content);
     const chainRpcUrls = parseChainRpcUrls(event.content);
     peers.push({
@@ -323,6 +367,7 @@ export async function discoverAnnouncedPeers(
       info,
       ...(routes ? { routes } : {}),
       ...(capabilities ? { capabilities } : {}),
+      ...(routePrices ? { routePrices } : {}),
       ...(minaTokenIds ? { minaTokenIds } : {}),
       ...(chainRpcUrls ? { chainRpcUrls } : {}),
       createdAt: event.created_at,

--- a/packages/rig/src/standalone/standalone-publisher.test.ts
+++ b/packages/rig/src/standalone/standalone-publisher.test.ts
@@ -1412,3 +1412,107 @@ describe('extractArweaveTxId', () => {
     expect(() => extractArweaveTxId(answer(500, 'oops'))).toThrow(/HTTP 500/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Store leg
+//
+// When the store route terminates on its own node, that node holds its own
+// payment channel. Paying it with a claim signed on the PUBLISH channel is
+// refused outright — `F01 - claim rejected: names a channel this connector
+// has no record of, so there is no counterparty to verify its signature
+// against` — which is what made every `rig push` against the two-box fleet
+// fail on the first git object. These assert on WHICH channel the claim is
+// signed against, because a test that only checks the upload succeeds would
+// still pass with both legs sharing one channel.
+// ---------------------------------------------------------------------------
+
+describe('store leg — a store write is paid on the STORE channel', () => {
+  function twoLeg(lockDir: string) {
+    const publish = mockClient();
+    const store = mockClient();
+    // Distinguish the two legs by the channel each opens.
+    store.client.openChannel = async (destination?: string) => {
+      store.calls.openChannel.push(destination);
+      return 'store-channel-1';
+    };
+    const publisher = new StandalonePublisher({
+      client: publish.client,
+      storeClient: store.client,
+      channelDestination: 'g.proxy.relay',
+      storeDestination: 'g.proxy.store',
+      publishDestination: 'g.proxy.relay',
+      lockDir,
+      fetchImpl: noDaemon,
+    });
+    return { publisher, publish, store };
+  }
+
+  it('signs the git-object claim on the store channel, not the publish channel', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rig-store-leg-'));
+    const { publisher, publish, store } = twoLeg(dir);
+    await publisher.uploadGitObject({
+      sha: 'a'.repeat(40),
+      type: 'blob',
+      body: Buffer.from('hello'),
+      repoId: 'demo',
+    });
+
+    // The claim the store node verifies must name ITS channel.
+    expect(store.calls.claims.map((c) => c.channelId)).toEqual([
+      'store-channel-1',
+    ]);
+    // and the publish channel must not have been charged for it.
+    expect(publish.calls.claims).toEqual([]);
+    expect(store.calls.publishes[0]?.options?.destination).toBe(
+      'g.proxy.store'
+    );
+    await publisher.stop();
+  });
+
+  it('opens the store channel against the STORE destination', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rig-store-leg-'));
+    const { publisher, store } = twoLeg(dir);
+    await publisher.uploadGitObject({
+      sha: 'b'.repeat(40),
+      type: 'blob',
+      body: Buffer.from('hi'),
+      repoId: 'demo',
+    });
+    expect(store.calls.openChannel).toEqual(['g.proxy.store']);
+    await publisher.stop();
+  });
+
+  it('builds the store leg lazily — a publish-only run opens no store channel', async () => {
+    // A second on-chain channel costs gas; a run with nothing to upload must
+    // not open one.
+    const dir = mkdtempSync(join(tmpdir(), 'rig-store-leg-'));
+    const { publisher, store } = twoLeg(dir);
+    await publisher.publishEvent(
+      { kind: 30618, content: '', created_at: 1, tags: [] },
+      ['wss://relay.example.test']
+    );
+    expect(store.calls.start).toBe(0);
+    expect(store.calls.openChannel).toEqual([]);
+    await publisher.stop();
+  });
+
+  it('falls back to the publish channel when no store leg is configured', async () => {
+    // Single-node topology: one client, one channel — unchanged behaviour.
+    const dir = mkdtempSync(join(tmpdir(), 'rig-store-leg-'));
+    const publish = mockClient();
+    const publisher = new StandalonePublisher({
+      client: publish.client,
+      channelDestination: 'g.proxy.relay.store',
+      lockDir: dir,
+      fetchImpl: noDaemon,
+    });
+    await publisher.uploadGitObject({
+      sha: 'c'.repeat(40),
+      type: 'blob',
+      body: Buffer.from('x'),
+      repoId: 'demo',
+    });
+    expect(publish.calls.claims.map((c) => c.channelId)).toEqual(['channel-1']);
+    await publisher.stop();
+  });
+});

--- a/packages/rig/src/standalone/standalone-publisher.ts
+++ b/packages/rig/src/standalone/standalone-publisher.ts
@@ -146,6 +146,16 @@ export interface WalletViewFallback {
   minaChannel?: ToonClientConfig['minaChannel'];
 }
 
+/**
+ * The client + channel one leg of the write path pays on. Two legs exist
+ * only when the store route terminates on a different node than publishes;
+ * otherwise both names point at the same client and channel.
+ */
+interface StoreLeg {
+  client: ToonClientLike;
+  channelId: string;
+}
+
 export interface StandalonePublisherOptions {
   /**
    * ToonClient config (mnemonic + mnemonicAccountIndex + proxy/BTP uplink +
@@ -171,6 +181,32 @@ export interface StandalonePublisherOptions {
    * config's `destinationAddress`.
    */
   channelDestination?: string;
+  /**
+   * Client config for a SECOND uplink dedicated to store writes, when the
+   * store route terminates on a different node than publishes.
+   *
+   * A balance-proof claim is only verifiable by the connector holding that
+   * channel — one with no record of it refuses the packet (`F01 - claim
+   * rejected: names a channel this connector has no record of`). The store
+   * node has its own settlement address and its own channel, and on the
+   * two-box fleet the publish node has no route to it, so a store write
+   * cannot ride the publish session. Given this, store writes go out on
+   * their own client, against their own channel, recorded under their own
+   * anchor so `rig channel` still sees it.
+   *
+   * A separate CLIENT rather than a second destination on the existing one
+   * because `@toon-protocol/client` carries a single `btpUrl` per instance —
+   * there is no per-destination uplink to configure. Omitted (the
+   * single-node case) keeps the historical behaviour: one client, one
+   * channel, store writes on the publish session.
+   */
+  storeClientConfig?: ToonClientConfig;
+  /**
+   * Pre-built store-leg client (tests / advanced callers) — the store-side
+   * counterpart of `client`, and mutually exclusive with
+   * `storeClientConfig` in the same way.
+   */
+  storeClient?: ToonClientLike;
   /** Flat fee per published event (daemon `feePerEvent` convention). Default 1n. */
   eventFee?: bigint;
   /**
@@ -396,6 +432,13 @@ export class StandalonePublisher implements Publisher {
     | undefined;
   private readonly warn: (line: string) => void;
 
+  private readonly storeClientConfig: ToonClientConfig | undefined;
+  private readonly injectedStoreClient: ToonClientLike | undefined;
+  /** Lazily built on the first store write — see {@link storeLeg}. */
+  private storeClient: ToonClientLike | undefined;
+  private storeChannelId: string | undefined;
+  private storeLegPromise: Promise<StoreLeg> | undefined;
+
   private lock: NonceLock | undefined;
   private channelId: string | undefined;
   private readyPromise: Promise<void> | undefined;
@@ -439,6 +482,13 @@ export class StandalonePublisher implements Publisher {
     this.fetchImpl = options.fetchImpl;
     this.channelMap = options.channelMap;
     this.channelAnchor = anchor;
+    if (options.storeClient && options.storeClientConfig) {
+      throw new Error(
+        'StandalonePublisher: provide either `storeClientConfig` or `storeClient`, not both'
+      );
+    }
+    this.storeClientConfig = options.storeClientConfig;
+    this.injectedStoreClient = options.storeClient;
     this.negotiationFallbacks = options.negotiationFallbacks;
     this.warn = options.warn ?? ((line) => process.stderr.write(`${line}\n`));
   }
@@ -564,40 +614,72 @@ export class StandalonePublisher implements Publisher {
    * file throws BEFORE anything is opened — never a silent duplicate open.
    */
   private async openOrResumeChannel(): Promise<string> {
+    return this.openOrResumeChannelOn(this.client, this.channelDestination, {
+      anchor: this.channelAnchor,
+      trackResumeState: true,
+    });
+  }
+
+  /**
+   * {@link openOrResumeChannel} for an arbitrary client + destination, so
+   * the store leg gets the same resume-before-open guarantee (and the same
+   * corruption check) as the publish leg rather than a second, weaker path.
+   *
+   * `anchor` defaults to the destination: a leg other than the publish one
+   * is keyed in the channel map by the route it pays for.
+   * `trackResumeState` is publish-only — {@link lastOpenResumed} feeds the
+   * `resumed` field of this publisher's channel status, which describes the
+   * publish channel and would be wrong to overwrite from a store open.
+   */
+  private async openOrResumeChannelOn(
+    client: ToonClientLike,
+    destination: string | undefined,
+    opts: { anchor?: string; trackResumeState?: boolean } = {}
+  ): Promise<string> {
     const map = this.channelMap;
+    const trackResumeState = opts.trackResumeState ?? false;
     if (!map) {
       // No persistence configured: historical lazy open, nothing recorded.
-      return this.client.openChannel(this.channelDestination);
+      return client.openChannel(destination);
     }
-    if (!this.channelAnchor) {
+    const anchorFor = opts.anchor ?? destination;
+    if (!anchorFor) {
       this.warn(
         'rig: no channel anchor destination configured — the peer→channel ' +
           'mapping cannot be persisted, so this run may open a fresh channel'
       );
-      return this.client.openChannel(this.channelDestination);
+      return client.openChannel(destination);
     }
 
-    const anchor = this.channelAnchor;
-    const identity = this.client.getPublicKey();
+    const anchor = anchorFor;
+    const identity = client.getPublicKey();
     // Corruption check happens HERE, before any on-chain open (throws).
     const candidates = map.listFor(identity, anchor);
-    const internals = channelInternals(this.client);
+    const internals = channelInternals(client);
     const resumed = await this.resumeRecordedChannel(
       map,
       candidates,
-      internals
+      internals,
+      client
     );
 
     // Idempotent — returns the (resumed or existing) channel for the peer if
     // one is tracked, else opens lazily on-chain.
-    const channelId = await this.client.openChannel(this.channelDestination);
+    const channelId = await client.openChannel(destination);
 
     if (resumed && channelId === resumed.channelId) {
-      this.lastOpenResumed = true;
+      if (trackResumeState) this.lastOpenResumed = true;
       map.touch(recordKey(resumed));
     } else {
-      this.lastOpenResumed = false;
-      this.recordOpenedChannel(map, internals, identity, anchor, channelId);
+      if (trackResumeState) this.lastOpenResumed = false;
+      this.recordOpenedChannel(
+        map,
+        internals,
+        identity,
+        anchor,
+        channelId,
+        client
+      );
     }
     return channelId;
   }
@@ -610,7 +692,12 @@ export class StandalonePublisher implements Publisher {
   private async resumeRecordedChannel(
     map: ChannelMapStore,
     candidates: ChannelMapRecord[],
-    internals: ChannelInternals
+    internals: ChannelInternals,
+    // The client this leg pays on. Deposit bookkeeping must read from the
+    // SAME client that tracks the channel — reading the publish client for a
+    // store channel reports "is not being tracked" and records a deposit of
+    // undefined against a real, funded channel.
+    client: ToonClientLike
   ): Promise<ChannelMapRecord | undefined> {
     if (candidates.length === 0) return undefined;
     const cm = internals.channelManager;
@@ -675,10 +762,10 @@ export class StandalonePublisher implements Publisher {
       if (
         record.context.chainType === 'evm' &&
         record.depositTotal === undefined &&
-        this.client.rehydrateChannelDeposit
+        client.rehydrateChannelDeposit
       ) {
         try {
-          const deposit = await this.client.rehydrateChannelDeposit(
+          const deposit = await client.rehydrateChannelDeposit(
             record.channelId,
             {
               chain: record.chain,
@@ -708,7 +795,11 @@ export class StandalonePublisher implements Publisher {
     internals: ChannelInternals,
     identity: string,
     destination: string,
-    channelId: string
+    channelId: string,
+    // The client this leg pays on — the deposit must be read from the client
+    // that actually tracks the channel, not from whichever one happens to be
+    // the publish client.
+    client: ToonClientLike
   ): void {
     // `peerChannels` is keyed by the COMPOSITE binding key, not the peer id
     // (toon-client#489) — read the peer id back out of it.
@@ -735,7 +826,7 @@ export class StandalonePublisher implements Publisher {
 
     let depositTotal: bigint | undefined;
     try {
-      depositTotal = this.client.getChannelDepositTotal?.(channelId);
+      depositTotal = client.getChannelDepositTotal?.(channelId);
     } catch {
       // deposit unknown — recorded without it; a later resume re-reads it
     }
@@ -777,6 +868,16 @@ export class StandalonePublisher implements Publisher {
     this.channelId = undefined;
     // Never stop a client that was never started (`ToonClient.stop()` throws
     // INVALID_STATE) — e.g. after a free `rig balance` read (#263).
+    // The store leg owns its client outright (it is only ever built here),
+    // so it is stopped regardless of `ownsClient` — that flag describes the
+    // caller-injectable publish client.
+    if (this.storeClient) {
+      const storeClient = this.storeClient;
+      this.storeClient = undefined;
+      this.storeLegPromise = undefined;
+      this.storeChannelId = undefined;
+      await storeClient.stop();
+    }
     if (this.ownsClient && this.client.isStarted?.() !== false) {
       await this.client.stop();
     }
@@ -983,7 +1084,7 @@ export class StandalonePublisher implements Publisher {
       );
     }
     await this.start();
-    const channelId = this.requireChannel();
+    const leg = await this.storeLeg();
 
     const contentType =
       upload.type === 'blob'
@@ -991,7 +1092,7 @@ export class StandalonePublisher implements Publisher {
         : DEFAULT_CONTENT_TYPE;
 
     const fee = this.uploadFee();
-    const event = this.client.signEvent({
+    const event = leg.client.signEvent({
       kind: 5094,
       content: '',
       created_at: nowSeconds(),
@@ -1005,8 +1106,8 @@ export class StandalonePublisher implements Publisher {
       ],
     });
 
-    const claim = await this.client.signBalanceProof(channelId, fee);
-    const result = await this.client.publishEvent(event, {
+    const claim = await leg.client.signBalanceProof(leg.channelId, fee);
+    const result = await leg.client.publishEvent(event, {
       ...(this.storeDestination ? { destination: this.storeDestination } : {}),
       claim,
       ilpAmount: fee,
@@ -1041,10 +1142,10 @@ export class StandalonePublisher implements Publisher {
       );
     }
     await this.start();
-    const channelId = this.requireChannel();
+    const leg = await this.storeLeg();
 
     const fee = this.uploadFee();
-    const event = this.client.signEvent({
+    const event = leg.client.signEvent({
       kind: 5094,
       content: '',
       created_at: nowSeconds(),
@@ -1056,8 +1157,8 @@ export class StandalonePublisher implements Publisher {
       ],
     });
 
-    const claim = await this.client.signBalanceProof(channelId, fee);
-    const result = await this.client.publishEvent(event, {
+    const claim = await leg.client.signBalanceProof(leg.channelId, fee);
+    const result = await leg.client.publishEvent(event, {
       ...(this.storeDestination ? { destination: this.storeDestination } : {}),
       claim,
       ilpAmount: fee,
@@ -1122,6 +1223,45 @@ export class StandalonePublisher implements Publisher {
       );
     }
     return this.channelId;
+  }
+
+  /**
+   * The client + channel a STORE write must be paid on.
+   *
+   * With no `storeClientConfig` this is the publish leg unchanged — the
+   * single-node case, where the store terminates on the connector that
+   * already holds the channel. With one, the store node is a different
+   * connector holding a different channel, and paying it from the publish
+   * channel is precisely the `F01 - claim rejected: names a channel this
+   * connector has no record of` failure this exists to prevent.
+   *
+   * Built on FIRST STORE WRITE, not in `start()`: `rig push` with nothing to
+   * upload, and every read-only command, should not open a second on-chain
+   * channel (gas) for a leg they never use. Memoised on the promise so
+   * concurrent uploads share one open rather than racing two.
+   */
+  private async storeLeg(): Promise<StoreLeg> {
+    const injected = this.injectedStoreClient;
+    const config = this.storeClientConfig;
+    if (!config && !injected) {
+      return { client: this.client, channelId: this.requireChannel() };
+    }
+    this.storeLegPromise ??= (async (): Promise<StoreLeg> => {
+      const client = injected ?? new ToonClient(config as ToonClientConfig);
+      this.storeClient = client;
+      await client.start();
+      // The store node is a distinct peer: its channel is recorded under the
+      // store destination as its own anchor, so `rig channel list/close/
+      // settle` enumerate it alongside the publish channel instead of it
+      // becoming invisible collateral.
+      const channelId = await this.openOrResumeChannelOn(
+        client,
+        this.storeDestination
+      );
+      this.storeChannelId = channelId;
+      return { client, channelId };
+    })();
+    return this.storeLegPromise;
   }
 }
 

--- a/packages/rig/src/standalone/topology-cache.ts
+++ b/packages/rig/src/standalone/topology-cache.ts
@@ -58,7 +58,7 @@ export function topologyCacheTtlMs(env: NodeJS.ProcessEnv): number {
  * v1 topology has no `btpUrl`, so paid writes would have kept 401ing for 15
  * minutes after the upgrade.
  */
-export const TOPOLOGY_SCHEMA_VERSION = 2;
+export const TOPOLOGY_SCHEMA_VERSION = 3;
 
 /**
  * Stable cache key: schema tag + relay-origin + identity pubkey + the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.4.0
       '@toon-protocol/client':
-        specifier: ^0.29.7
-        version: 0.29.7(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^0.29.8
+        version: 0.29.8(typescript@5.9.3)(zod@3.25.76)
       '@toon-protocol/core':
         specifier: ^3.2.0
         version: 3.2.0(typescript@5.9.3)
@@ -8367,8 +8367,8 @@ packages:
       - zod
     dev: true
 
-  /@toon-protocol/client@0.29.7(typescript@5.9.3)(zod@3.25.76):
-    resolution: {integrity: sha512-boI9yU7gKLgH0CeLuNy6CIsZKd7or4n4uuvTaATOpSONh45kil6LWUURANkNSSHE43YJgV/W0A6vNW+7CTVmQw==}
+  /@toon-protocol/client@0.29.8(typescript@5.9.3)(zod@3.25.76):
+    resolution: {integrity: sha512-obBrcM4b5E3nCNEMgiV5DoxRTQr/mBtaMOwXOQtAqIa7lv9HN+xrl16h9I6iPn+lulyqfH4w3qZ0xVnUMb+Rjg==}
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.2.0


### PR DESCRIPTION
`rig push` signed the git-object claim on the **publish** channel and sent it to the **store** node, which has no record of that channel and refuses it:

```
F01 - claim rejected: names a channel this connector has no record of,
      so there is no counterparty to verify its signature against
```

Traced on the wire for a single push: the relay box saw `POST /ilp` 402 ×2 then `GET /ilp/btp` **101** (a real session and channel); the store box saw only `GET /ilp/identity` 200 — no BTP upgrade, no channel, ever.

There is no transit to lean on. Both boxes' live `connector-rust.toml` show the publish node declaring exactly one route, its own publish prefix. It has no route to the store address, so a client must reach the store node **directly**.

## The fix

The store leg gets its own uplink, its own channel, and its own watermark file:

- **Uplink** resolved from the **store node's own** kind:10032 announce, matched by the `ilpAddress` it publishes for itself. Each node publishes only its own BTP ingress; the payment peer's announce names the store *route* but carries no way to reach it. No baked fallback — guessing a store endpoint would send real claims to a node nobody advertised.
- **Channel** opened against that node's settlement address, recorded under the store destination as its own anchor so `rig channel list/close/settle` still enumerate it rather than it becoming invisible collateral.
- **Watermark file** of its own. Two live clients pointed at one channel store rewrite it wholesale and clobber each other — observed as the publish leg losing its channel ("is not being tracked", then F01) the moment the store leg opened.
- **Built lazily** on the first store write, so a publish-only run and every read-only command open no second on-chain channel. Gas is the scarce resource on this devnet.

A separate *client* rather than a second destination on the existing one because `@toon-protocol/client` carries a single `btpUrl` per instance — there is no per-destination uplink to configure.

## Two supporting fixes it uncovered

1. **Route prices were never read on this fleet.** Rig parsed only the `capabilities` array, but the live connector publishes a `routePrices` map. With no price the upload fee floored at 0 and the store answered `F03 - claim rejected: advances value by 0, less than this route's price of 1000`. Prices are now read from both shapes, and from the announce of whichever node terminates the address — each node prices its own routes.
2. **A pinned store route skipped discovery.** A config pinning `storeDestination` on a different node counted as "fully explicit", so rig never ran discovery and never learned the store endpoint. It now also requires that node's uplink (`storeBtpUrl` / `TOON_CLIENT_STORE_BTP_URL`) before it counts as explicit.

`TOPOLOGY_SCHEMA_VERSION` bumped to 3 so a cached pre-fix topology can't shadow this for the TTL.

## Verified end to end on the live devnet

Against connector `rust-sha-1204220`, from a clean channel state:

```
Pushed "rigdemoF":
  object 31c4d29a2fb9  paid 1,000  ar:d71Qlq8BbZlTQOi8XCPRJXF1RIH20Tx1Twq2s8vNHlM
  object b39b472d8e5f  paid 1,000  ar:tC6LgbAWMdfYPE2-lwjYVdc4a2ylXQpBwn26sjwWzF4
  object 193f8ec6c0f0  paid 1,000  ar:4iCk_tGTLPKBDr2AojVvsjZeNTmBNPqyo5koKAu7YOw
Announcement (kind:30617): 06a88b42cd5b…  paid 1,000
Refs event (kind:30618):   39b4468aae2e…  paid 1,000
Total paid: 5,000 base units (estimate was 5,000)
Rig page: https://ar-io.dev/xRd_BK89WEHGzKLxbwMvUpvzncxRtjXdgWYcDqDhFQ0
```

## ⚠️ Blocked on a `@toon-protocol/client` release

This fix is **necessary but not sufficient**. I tested it directly: with the published `0.29.7`, the store leg still fails `F01`. It needs the per-destination counterparty resolution from toon-client#571, which is merged to toon-client `main` but **not on npm** — release PR toon-protocol/toon-client#570 is open and carries it. The green run above used a build of that `main`.

So: merge this, but rig will not actually push until that client release ships and the dependency is bumped. Left on `^0.29.7` rather than pinning something unpublished.

## Tests

New coverage in both sibling suites, asserting on **which channel the claim is signed against** — a test that only checked the upload succeeded would still pass with both legs sharing one channel. Verified the tests bite: reverting only the store-leg branch turns exactly the two channel-identity assertions red.

Gate green at the frozen baseline: `eslint 0e/220w, typecheck 0e`, gate tests 22/22, `pnpm -r test` 1032 + 357 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)