### PR TITLE
rig name buy/set --via travel the paid ILP path instead of a bare fetch

### DIFF
--- a/.changeset/brokered-arns-over-paid-ilp.md
+++ b/.changeset/brokered-arns-over-paid-ilp.md
@@ -1,0 +1,56 @@
+---
+'@toon-protocol/rig': patch
+---
+
+`rig name buy/set --via` travel the paid ILP path instead of a bare fetch
+
+`--via` used to do a raw `fetch(${viaUrl}/store)`. No connector serves
+`/store`, so the brokered ArNS path could not work against any node:
+
+| endpoint | `/store` | `/ilp` |
+|---|---|---|
+| `dvm.devnet.toonprotocol.dev` (the shipped default) | 404 | — |
+| a third-party node's client edge | 404 | 400 |
+| `proxy.ario.devnet.toonprotocol.dev` | 404 | 400 |
+
+The endpoint is absent by design, not by oversight. The store sits behind the
+connector's payment termination, so a publicly reachable `POST /store` is an
+unpaid path to a paid handler — the free-gateway failure ADR 0020 names, and
+the exact door the devnet store box closed on 2026-08-05 (it let anyone spend
+that box's funded Arweave wallet for free). The default `dvm.` hostname is a
+second dead end on top of that: it maps to the store's BLS **health** server,
+whose app registers exactly one route, `GET /health`.
+
+So `--via` changes meaning: it now names an **ILP destination**, and the job
+rides a paid packet with `/store` as the envelope target beneath the route's
+handler path — the same transport `rig push` already uses for kind:5094
+git-object writes. The kind:5095/5096 `param` tags are unchanged, so the
+handler sees the identical event either way.
+
+- `Publisher` gains an optional `submitStoreJob`, following `uploadBlob`'s
+  optional-method pattern. A DVM refusal comes back as **data rather than an
+  exception**: under ADR 0020 `accept: false` arrives on a FULFILL and the
+  payer was charged either way, and the zero-ARIO rehearsal (submit a buy with
+  no `processId`, watch the handler refuse by name before it quotes or touches
+  the registry) is the cheapest proof the whole paid path works.
+- `StandalonePublisher.submitStoreJob` mirrors `uploadGitObject`: the store
+  leg's own channel, one claim at the store route's flat price, a `bid` tag
+  carrying that same figure, `proxyPath: '/store'`.
+- `StandaloneLoadOptions` gains `storeDestination`, at highest precedence over
+  `TOON_CLIENT_STORE_DESTINATION` and the config file, since it is a
+  per-invocation choice rather than a setting.
+- The devnet default is repointed from the unreachable
+  `https://dvm.devnet.toonprotocol.dev` to the ILP destination `g.toon.ario`,
+  which is the path that is actually paid and actually works.
+- The override is weighed in `createStandaloneContext`'s announce-discovery
+  gate too. Without that, a config pinning store == publish reads as fully
+  explicit, discovery is skipped, and the announce of the node `--via` actually
+  names — the only thing carrying its uplink, price and channel — is never
+  fetched. A pinned `storeBtpUrl` likewise vouches for nothing once `--via`
+  names a different node.
+- A URL in `--via` is **rejected** with the destination form in the error,
+  rather than failing later as an unroutable address. A URL means the caller
+  still expects the old direct-POST path.
+- `RIG_ARNS_DVM_DESTINATION` is the env spelling; `RIG_ARNS_DVM_URL` is still
+  read so an existing environment keeps working, and `DEVNET_DVM_URL` stays
+  exported as a deprecated alias of `DEVNET_DVM_DESTINATION`.

--- a/packages/rig/README.md
+++ b/packages/rig/README.md
@@ -347,7 +347,16 @@ authoritative doc is
 | Faucet (web UI + API) | `https://faucet.devnet.toonprotocol.dev` |
 | Relay (free reads, `rig clone`/`fetch`) | `wss://relay-ws.devnet.toonprotocol.dev` |
 | Payment proxy (paid writes, BTP) | `wss://proxy.devnet.toonprotocol.dev:443` |
-| Store DVM (ArNS buyfor/gas-station jobs, `--via`) | `https://dvm.devnet.toonprotocol.dev` |
+| Store DVM (ArNS buyfor/gas-station jobs, `--via`) | `g.toon.ario` (an ILP **destination**, not a URL — see below) |
+
+`--via` names an ILP destination rather than an HTTP endpoint. The store sits
+behind the connector's payment termination, so it has no public job endpoint to
+POST to, and a reachable one would be an unpaid path to a paid handler. The
+kind:5095 buy and kind:5096 gas-station jobs therefore travel as paid packets,
+exactly as `rig push`'s git-object writes do. Everything else about that node —
+its BTP ingress, its route price, the payment channel to open against it — is
+discovered from its own kind:10032 announce, so the destination is the only
+thing you supply.
 
 ### Faucet routes
 

--- a/packages/rig/src/cli/name.test.ts
+++ b/packages/rig/src/cli/name.test.ts
@@ -28,7 +28,7 @@ import {
   ARNS_NULL_PROCESS_ID,
   defaultLoadArns,
   DVM_PAYMENT_NOTE,
-  DEVNET_DVM_URL,
+  DEVNET_DVM_DESTINATION,
   MARIO_PAYMENT_NOTE,
   MIN_ARIO_SDK_VERSION,
   runName,
@@ -41,6 +41,8 @@ import {
   type NameDeps,
   type SubmitDvmBuyJob,
 } from './name.js';
+import type { IdentitySourceKind } from './identity.js';
+import type { LoadStandalone } from './standalone-context.js';
 
 /** Standard BIP-39 test vector phrase — deterministic, never funded. */
 const MNEMONIC =
@@ -186,8 +188,21 @@ interface Harness {
   /** Every kind:5095 job the stubbed DVM submitter received (--via). */
   dvmJobs: DvmBuyJobRequest[];
   /** Every kind:5096 gas-station call the stubbed client received. */
-  gasQuotes: { viaUrl: string; transaction?: string }[];
-  gasExecutes: { viaUrl: string; transaction: string; quoteId: string; idempotencyKey: string }[];
+  gasQuotes: { destination: string; transaction?: string }[];
+  gasExecutes: {
+    destination: string;
+    transaction: string;
+    quoteId: string;
+    idempotencyKey: string;
+  }[];
+  /**
+   * Every `storeDestination` a paid session was opened for (#101). One entry
+   * per `--via` invocation; empty means no session was opened, which is what
+   * a pure estimate must show.
+   */
+  sessions: string[];
+  /** How many times a session was torn down — must match `sessions`. */
+  sessionStops: number;
 }
 
 function makeHarness(
@@ -244,12 +259,13 @@ function makeHarness(
   const gasStation: GasStationClient = {
     quote: async (args) => {
       gasQuotes.push({
-        viaUrl: args.viaUrl,
+        destination: args.destination,
         ...(args.transaction !== undefined
           ? { transaction: args.transaction }
           : {}),
       });
-      expect(args.nostrSecretKey).toHaveLength(32);
+      // #101: the seam carries a paid transport, never key material.
+      expect(typeof args.submit).toBe('function');
       return {
         quoteId: 'quote-1',
         feePayer: 'GASWALLETADDR',
@@ -260,7 +276,7 @@ function makeHarness(
     },
     execute: async (args) => {
       gasExecutes.push({
-        viaUrl: args.viaUrl,
+        destination: args.destination,
         transaction: args.transaction,
         quoteId: args.quoteId,
         idempotencyKey: args.idempotencyKey,
@@ -272,6 +288,42 @@ function makeHarness(
       };
     },
   };
+  // #101: `--via` opens a paid session against the store node. The fake
+  // records which destination it was pointed at and never touches the network,
+  // so no test can pay for a packet.
+  const sessions: string[] = [];
+  let sessionStops = 0;
+  const loadStandalone: LoadStandalone = async (options) => {
+    sessions.push(options.storeDestination ?? '<none>');
+    return {
+      ownerPubkey: 'f'.repeat(64),
+      identitySource: 'env' as IdentitySourceKind,
+      identitySourceLabel: 'RIG_MNEMONIC env',
+      publisher: {
+        getFeeRates: async () => ({ uploadFee: 1000n, eventFee: 1000n }),
+        uploadGitObject: async () => {
+          throw new Error('not used by rig name');
+        },
+        publishEvent: async () => {
+          throw new Error('not used by rig name');
+        },
+        submitStoreJob: async () => {
+          throw new Error(
+            'the job seams are stubbed in these tests; submitStoreJob should ' +
+              'never be reached'
+          );
+        },
+      },
+      defaultRelayUrls: [],
+      fetchRemote: async () => {
+        throw new Error('not used by rig name');
+      },
+      stop: async () => {
+        sessionStops += 1;
+      },
+    };
+  };
+
   const deps: NameDeps = {
     io,
     env,
@@ -279,6 +331,7 @@ function makeHarness(
     loadArns,
     submitDvmBuyJob,
     gasStation,
+    loadStandalone,
     resolveToonNetwork: async () => ({
       network: undefined,
       effectiveNetwork: opts.toonDevnet ? 'devnet' : undefined,
@@ -296,6 +349,10 @@ function makeHarness(
     dvmJobs,
     gasQuotes,
     gasExecutes,
+    sessions,
+    get sessionStops() {
+      return sessionStops;
+    },
     get loadArnsCalls() {
       return loadArnsCalls;
     },
@@ -802,7 +859,7 @@ describe('rig name', () => {
   it('--via --json without --yes is a pure estimate: no spawn, no job, read-only SDK', async () => {
     const h = makeHarness(env, cwd);
     const code = await runName(
-      ['buy', 'toon-buyfor-e2e', '--via', 'http://dvm.local:3300', '--json'],
+      ['buy', 'toon-buyfor-e2e', '--via', 'g.drew.ario', '--json'],
       h.deps
     );
     expect(code).toBe(0);
@@ -811,7 +868,7 @@ describe('rig name', () => {
       command: 'name',
       action: 'buy',
       executed: false,
-      via: 'http://dvm.local:3300',
+      via: 'g.drew.ario',
       payment: DVM_PAYMENT_NOTE,
     });
     expect(h.calls.spawnAnt).toHaveLength(0);
@@ -827,7 +884,7 @@ describe('rig name', () => {
         'buy',
         'toon-buyfor-e2e',
         '--via',
-        'http://dvm.local:3300',
+        'g.drew.ario',
         '--network',
         'devnet',
         '--yes',
@@ -840,7 +897,7 @@ describe('rig name', () => {
     expect(doc).toMatchObject({
       executed: true,
       network: 'devnet',
-      via: 'http://dvm.local:3300',
+      via: 'g.drew.ario',
       spawn: { processId: 'SPAWNED-ANT-ID', signature: 'spawn-tx-1' },
       result: {
         registryTxId: 'dvm-registry-tx-1',
@@ -855,20 +912,20 @@ describe('rig name', () => {
     expect(h.calls.buyRecord).toHaveLength(0);
     expect(h.dvmJobs).toHaveLength(1);
     expect(h.dvmJobs[0]).toMatchObject({
-      viaUrl: 'http://dvm.local:3300',
+      destination: 'g.drew.ario',
       name: 'toon-buyfor-e2e',
       type: 'lease',
       years: 1,
       processId: 'SPAWNED-ANT-ID',
     });
-    expect(h.dvmJobs[0]!.nostrSecretKey).toHaveLength(32);
+    expect(typeof h.dvmJobs[0]!.submit).toBe('function');
     expect(h.loadArnsModes).toEqual(['read', 'write']);
   });
 
   it('--via refuses without --yes when non-interactive (nothing spawned or submitted)', async () => {
     const h = makeHarness(env, cwd);
     const code = await runName(
-      ['buy', 'toon-buyfor-e2e', '--via', 'http://dvm.local:3300'],
+      ['buy', 'toon-buyfor-e2e', '--via', 'g.drew.ario'],
       h.deps
     );
     expect(code).toBe(1);
@@ -882,7 +939,7 @@ describe('rig name', () => {
       dvm: { error: new Error('the DVM rejected the kind:5095 buy job (T00): insufficient ARIO balance') },
     });
     const code = await runName(
-      ['buy', 'toon-buyfor-e2e', '--via', 'http://dvm.local:3300', '--yes', '--json'],
+      ['buy', 'toon-buyfor-e2e', '--via', 'g.drew.ario', '--yes', '--json'],
       h.deps
     );
     expect(code).toBe(1);
@@ -890,22 +947,85 @@ describe('rig name', () => {
     expect(String(doc['detail'])).toContain('insufficient ARIO balance');
     expect(h.calls.spawnAnt).toHaveLength(1);
     expect(h.calls.buyRecord).toHaveLength(0);
+    // #101: the session is torn down on the failure path too. It holds the
+    // identity lock, so leaking it wedges the next command.
+    expect(h.sessions).toEqual(['g.drew.ario']);
+    expect(h.sessionStops).toBe(1);
   });
 
-  it('--via must be an http(s) URL (usage error, no SDK load)', async () => {
+  it('buy --via opens the paid session against that destination, once, and closes it (#101)', async () => {
     const h = makeHarness(env, cwd);
     const code = await runName(
-      ['buy', 'toon-buyfor-e2e', '--via', 'wss://not-http'],
+      ['buy', 'toon-buyfor-e2e', '--via', 'g.drew.ario', '--yes', '--json'],
+      h.deps
+    );
+    expect(code).toBe(0);
+    // The destination `--via` named is what the store leg is pointed at, which
+    // is the whole of the #101 fix: everything else (BTP ingress, route price,
+    // payment channel) is discovered from that node's own announce.
+    expect(h.sessions).toEqual(['g.drew.ario']);
+    expect(h.sessionStops).toBe(1);
+  });
+
+  it('set --via opens ONE session covering both gas-station phases (#101)', async () => {
+    // Re-opening between quote and execute would risk expiring the quote's own
+    // blockhash deadline, so the pair must share a session.
+    const h = makeHarness(env, cwd);
+    const code = await runName(
+      ['set', 'mysite', TX_ID, '--via', 'g.drew.ario', '--yes', '--json'],
+      h.deps
+    );
+    expect(code).toBe(0);
+    expect(h.gasQuotes).toHaveLength(1);
+    expect(h.gasExecutes).toHaveLength(1);
+    expect(h.sessions).toEqual(['g.drew.ario']);
+    expect(h.sessionStops).toBe(1);
+  });
+
+  it('a pure estimate opens no paid session at all (#101)', async () => {
+    // Without --yes there is nothing to pay for, so nothing may be opened:
+    // a session costs an on-chain channel against the store node.
+    const h = makeHarness(env, cwd);
+    const code = await runName(
+      ['buy', 'toon-buyfor-e2e', '--via', 'g.drew.ario', '--json'],
+      h.deps
+    );
+    expect(code).toBe(0);
+    expect(h.sessions).toHaveLength(0);
+    expect(h.sessionStops).toBe(0);
+  });
+
+  it('--via rejects a URL and names the destination form instead (#101)', async () => {
+    // The pre-#101 spelling. It has to fail LOUDLY rather than be routed as an
+    // address, because a URL here means the caller still expects the direct
+    // `POST ${url}/store` path, which no connector serves and none should.
+    const h = makeHarness(env, cwd);
+    const code = await runName(
+      ['buy', 'toon-buyfor-e2e', '--via', 'https://dvm.devnet.toonprotocol.dev'],
       h.deps
     );
     expect(code).toBe(2);
-    expect(h.err.join('\n')).toContain('--via must be an http(s)');
+    expect(h.err.join('\n')).toContain('--via names an ILP destination, not a URL');
+    expect(h.err.join('\n')).toContain(DEVNET_DVM_DESTINATION);
     expect(h.loadArnsCalls).toBe(0);
+    expect(h.sessions).toHaveLength(0);
   });
 
-  it('RIG_ARNS_DVM_URL is the --via env fallback', async () => {
+  it('--via rejects a non-destination string (usage error, no SDK load)', async () => {
+    const h = makeHarness(env, cwd);
+    const code = await runName(
+      ['buy', 'toon-buyfor-e2e', '--via', 'not a destination'],
+      h.deps
+    );
+    expect(code).toBe(2);
+    expect(h.err.join('\n')).toContain('--via must be an ILP destination');
+    expect(h.loadArnsCalls).toBe(0);
+    expect(h.sessions).toHaveLength(0);
+  });
+
+  it('RIG_ARNS_DVM_DESTINATION is the --via env fallback', async () => {
     const h = makeHarness(
-      { ...env, RIG_ARNS_DVM_URL: 'http://dvm.env:3300' },
+      { ...env, RIG_ARNS_DVM_DESTINATION: 'g.env.ario' },
       cwd
     );
     const code = await runName(
@@ -914,7 +1034,7 @@ describe('rig name', () => {
     );
     expect(code).toBe(0);
     expect(h.dvmJobs).toHaveLength(1);
-    expect(h.dvmJobs[0]!.viaUrl).toBe('http://dvm.env:3300');
+    expect(h.dvmJobs[0]!.destination).toBe('g.env.ario');
     expect(h.calls.buyRecord).toHaveLength(0);
   });
 
@@ -928,7 +1048,7 @@ describe('rig name', () => {
         'mysite',
         TX_ID,
         '--via',
-        'http://dvm.local:3300',
+        'g.drew.ario',
         '--network',
         'devnet',
         '--yes',
@@ -942,7 +1062,7 @@ describe('rig name', () => {
       command: 'name',
       action: 'set',
       executed: true,
-      via: 'http://dvm.local:3300',
+      via: 'g.drew.ario',
       gasStation: {
         quoteId: 'quote-1',
         feePayer: 'GASWALLETADDR',
@@ -963,7 +1083,7 @@ describe('rig name', () => {
         recentBlockhash: 'QUOTEDBLOCKHASH',
       },
     ]);
-    expect(h.gasQuotes).toEqual([{ viaUrl: 'http://dvm.local:3300' }]);
+    expect(h.gasQuotes).toEqual([{ destination: 'g.drew.ario' }]);
     expect(h.gasExecutes).toHaveLength(1);
     expect(h.gasExecutes[0]).toMatchObject({
       transaction: 'BASE64-PARTIAL-TX',
@@ -977,12 +1097,12 @@ describe('rig name', () => {
   it('set --via --json without --yes is a pure preview (no quote, no build, no execute)', async () => {
     const h = makeHarness(env, cwd);
     const code = await runName(
-      ['set', 'mysite', TX_ID, '--via', 'http://dvm.local:3300', '--json'],
+      ['set', 'mysite', TX_ID, '--via', 'g.drew.ario', '--json'],
       h.deps
     );
     expect(code).toBe(0);
     const doc = JSON.parse(h.out.join('\n')) as Record<string, unknown>;
-    expect(doc).toMatchObject({ executed: false, via: 'http://dvm.local:3300' });
+    expect(doc).toMatchObject({ executed: false, via: 'g.drew.ario' });
     expect(h.gasQuotes).toHaveLength(0);
     expect(h.gasExecutes).toHaveLength(0);
     expect(h.calls.buildSetRecordTransaction).toHaveLength(0);
@@ -998,7 +1118,7 @@ describe('rig name', () => {
         '--undername',
         'docs',
         '--via',
-        'http://dvm.local:3300',
+        'g.drew.ario',
         '--yes',
         '--json',
       ],
@@ -1052,10 +1172,10 @@ describe('rig name', () => {
     // Brokered: our ANT spawned, the kind:5095 job hit the DEFAULT DVM, and
     // the local wallet never bought.
     expect(h.dvmJobs).toHaveLength(1);
-    expect(h.dvmJobs[0]?.viaUrl).toBe(DEVNET_DVM_URL);
+    expect(h.dvmJobs[0]?.destination).toBe(DEVNET_DVM_DESTINATION);
     expect(h.calls.buyRecord).toHaveLength(0);
     const doc = JSON.parse(h.out.join('\n')) as Record<string, unknown>;
-    expect(doc['via']).toBe(DEVNET_DVM_URL);
+    expect(doc['via']).toBe(DEVNET_DVM_DESTINATION);
     expect(h.err.join('\n')).toContain('Brokering via the devnet store DVM');
     expect(h.err.join('\n')).toContain('--direct');
   });
@@ -1068,7 +1188,7 @@ describe('rig name', () => {
     );
     expect(code).toBe(0);
     expect(h.gasQuotes).toHaveLength(1);
-    expect(h.gasQuotes[0]?.viaUrl).toBe(DEVNET_DVM_URL);
+    expect(h.gasQuotes[0]?.destination).toBe(DEVNET_DVM_DESTINATION);
     expect(h.calls.setBaseNameRecord).toHaveLength(0);
   });
 
@@ -1105,9 +1225,9 @@ describe('rig name', () => {
     expect(h.err.join('\n')).not.toContain('Brokering via the devnet store DVM');
   });
 
-  it('--direct also suppresses the ambient RIG_ARNS_DVM_URL', async () => {
+  it('--direct also suppresses the ambient RIG_ARNS_DVM_DESTINATION', async () => {
     const h = makeHarness(
-      { ...env, RIG_ARNS_DVM_URL: 'http://dvm.local:3300' },
+      { ...env, RIG_ARNS_DVM_DESTINATION: 'g.drew.ario' },
       cwd,
       { toonDevnet: true }
     );
@@ -1123,7 +1243,7 @@ describe('rig name', () => {
   it('--direct with an explicit --via is a usage error (exit 2)', async () => {
     const h = makeHarness(env, cwd);
     const code = await runName(
-      ['buy', 'mysite', '--via', 'http://dvm.local:3300', '--direct', '--yes'],
+      ['buy', 'mysite', '--via', 'g.drew.ario', '--direct', '--yes'],
       h.deps
     );
     expect(code).toBe(2);
@@ -1137,7 +1257,7 @@ describe('rig name', () => {
         'buy',
         'toon-demo-name',
         '--via',
-        'http://dvm.local:3300',
+        'g.drew.ario',
         '--network',
         'devnet',
         '--yes',
@@ -1147,7 +1267,7 @@ describe('rig name', () => {
     );
     expect(code).toBe(0);
     expect(h.dvmJobs).toHaveLength(1);
-    expect(h.dvmJobs[0]?.viaUrl).toBe('http://dvm.local:3300');
+    expect(h.dvmJobs[0]?.destination).toBe('g.drew.ario');
     expect(h.err.join('\n')).not.toContain('Brokering via the devnet store DVM');
   });
 });

--- a/packages/rig/src/cli/name.ts
+++ b/packages/rig/src/cli/name.ts
@@ -1061,7 +1061,7 @@ mnemonic that pays for pushes (derived at m/44'/501'/0'/0'). Fund it with
 registry program — NOT through TOON ILP payment channels.
 
 Commands:
-  name buy <name> [--years n | --permabuy] [--via <dvm-url>]
+  name buy <name> [--years n | --permabuy] [--via <destination>]
                        quote (mARIO) → confirm → register. The spawned ANT is
                        owned by this identity's Solana key. Default: 1-year
                        lease. PAID — spends mARIO from the Solana wallet.
@@ -1069,7 +1069,7 @@ Commands:
                        the ANT (dust SOL only), then a store DVM executes the
                        kind:5095 buy job and pays the mARIO from ITS wallet;
                        the name is owned by your ANT from inception.
-  name set <name> <txId> [--undername <sub>] [--ttl <seconds>] [--via <dvm-url>]
+  name set <name> <txId> [--undername <sub>] [--ttl <seconds>] [--via <destination>]
                        point the name (or an undername) at an Arweave txId
                        (typically a deployed path manifest). Signs an ANT
                        record update with the Solana key. With --via: the

--- a/packages/rig/src/cli/name.ts
+++ b/packages/rig/src/cli/name.ts
@@ -57,6 +57,9 @@ import { resolveEffectiveNetwork } from './fund.js';
 import { resolveIdentity } from './identity.js';
 import type { CliIo } from './output.js';
 import type { IdentityReport } from './push.js';
+import { defaultLoadStandalone } from './push.js';
+import type { StoreJobRequest, StoreJobResponse } from '../publisher.js';
+import type { LoadStandalone } from './standalone-context.js';
 import { renderIdentityLine } from './render.js';
 
 // ---------------------------------------------------------------------------
@@ -559,7 +562,8 @@ export const defaultLoadArns: LoadArns = async (options) => {
       } catch (err) {
         throw new ArnsSdkUnavailableError(err, '@ar.io/solana-contracts');
       }
-      const getSetRecordInstructionAsync = contracts.getSetRecordInstructionAsync;
+      const getSetRecordInstructionAsync =
+        contracts.getSetRecordInstructionAsync;
       const getAntRecordPDA = mod.getAntRecordPDA;
       const {
         createKeyPairFromBytes,
@@ -729,18 +733,36 @@ export const defaultLoadArns: LoadArns = async (options) => {
  */
 export const ARNS_BUY_JOB_KIND = 5095;
 
+/**
+ * Paid transport for one NIP-90 job to a store node's DVM (#101).
+ *
+ * This is {@link Publisher.submitStoreJob} narrowed to a function, so the two
+ * job seams below depend on the capability rather than on a whole publisher.
+ */
+export type SubmitStoreJob = (
+  request: StoreJobRequest
+) => Promise<StoreJobResponse>;
+
 /** One brokered buy job, ready to submit to a DVM. */
 export interface DvmBuyJobRequest {
-  /** The DVM endpoint `--via` resolved (the store backend base URL). */
-  viaUrl: string;
+  /**
+   * The store node's ILP destination that `--via` resolved. Carried for error
+   * messages only — the paid transport is {@link DvmBuyJobRequest.submit},
+   * which is already bound to this destination.
+   */
+  destination: string;
   name: string;
   type: NameType;
   /** Lease years; null for a permabuy. */
   years: number | null;
   /** The CLIENT's freshly-spawned ANT (asset pubkey) — the owner-to-be. */
   processId: string;
-  /** Nostr secret key that signs the job event (the rig identity). */
-  nostrSecretKey: Uint8Array;
+  /**
+   * Paid transport to that node's DVM. The job event is signed by the
+   * publisher's own identity, exactly as a kind:5094 store write is, so no
+   * key material travels through this seam.
+   */
+  submit: SubmitStoreJob;
 }
 
 /** What the DVM reports back for an executed buy job. */
@@ -767,88 +789,61 @@ export class DvmBuyJobError extends Error {
 }
 
 /**
- * Default {@link SubmitDvmBuyJob}: sign a kind:5095 event carrying the job as
- * NIP-90 `param` tags and POST it to the DVM's payment-oblivious `/store`
- * backend. This is the DIRECT interface — on the paid path the identical
- * event travels inside a paid ILP packet and the connector in front of the
- * DVM replays this same HTTP request after terminating payment
- * (RouteTermination), so the job shape is one and the same.
+ * Default {@link SubmitDvmBuyJob}: carry the kind:5095 job to the store node's
+ * DVM over the PAID path (#101).
+ *
+ * This used to `fetch(${viaUrl}/store)` directly. No connector serves `/store`
+ * and none should: the store sits behind the connector's payment termination,
+ * so a publicly reachable one would be an anonymous free gateway to a paid
+ * handler — exactly the failure ADR 0020 exists to close. The job now travels
+ * as a kind:5094 store write does, inside a paid ILP packet with `/store` as
+ * the envelope target beneath the route's handler path.
+ *
+ * The job's `param` tags are unchanged, so the handler sees the identical
+ * event either way.
  */
 export const defaultSubmitDvmBuyJob: SubmitDvmBuyJob = async (request) => {
-  const { finalizeEvent } = await import('nostr-tools/pure');
-  const event = finalizeEvent(
-    {
-      kind: ARNS_BUY_JOB_KIND,
-      created_at: Math.floor(Date.now() / 1000),
-      content: '',
-      tags: [
-        ['param', 'name', request.name],
-        ['param', 'type', request.type],
-        ...(request.years !== null
-          ? [['param', 'years', String(request.years)]]
-          : []),
-        ['param', 'processId', request.processId],
-      ],
-    },
-    request.nostrSecretKey
-  );
-
-  const url = `${request.viaUrl.replace(/\/+$/, '')}/store`;
-  let response: Response;
+  let answer;
   try {
-    response = await fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ event }),
+    answer = await request.submit({
+      kind: ARNS_BUY_JOB_KIND,
+      params: [
+        ['name', request.name],
+        ['type', request.type],
+        ...(request.years !== null
+          ? ([['years', String(request.years)]] as [string, string][])
+          : []),
+        ['processId', request.processId],
+      ],
     });
   } catch (err) {
     throw new DvmBuyJobError(
-      `could not reach the DVM at ${url}: ` +
+      `could not reach the DVM at ${request.destination}: ` +
         `${err instanceof Error ? err.message : String(err)}`
     );
   }
 
-  let body: {
-    accept?: boolean;
-    code?: string;
-    message?: string;
-    result?: {
-      registryTxId?: unknown;
-      quotedMario?: unknown;
-      syncAttributesTxId?: unknown;
-    };
-  };
-  try {
-    body = (await response.json()) as typeof body;
-  } catch {
+  if (!answer.accept) {
     throw new DvmBuyJobError(
-      `the DVM at ${url} returned a non-JSON response (HTTP ${response.status})`
+      `the DVM at ${request.destination} rejected the kind:${ARNS_BUY_JOB_KIND} ` +
+        `buy job (HTTP ${answer.status}${answer.code ? `, ${answer.code}` : ''})` +
+        `${answer.message ? `: ${answer.message}` : ''}`
     );
   }
-  if (!response.ok || body.accept !== true) {
-    throw new DvmBuyJobError(
-      `the DVM rejected the kind:${ARNS_BUY_JOB_KIND} buy job ` +
-        `(HTTP ${response.status}${body.code ? `, ${body.code}` : ''})` +
-        `${body.message ? `: ${body.message}` : ''}`
-    );
-  }
-  const registryTxId = body.result?.registryTxId;
+  const registryTxId = answer.result?.['registryTxId'];
   if (typeof registryTxId !== 'string' || registryTxId.length === 0) {
     throw new DvmBuyJobError(
       `the DVM accepted the job but returned no registryTxId — response: ` +
-        JSON.stringify(body.result ?? null)
+        JSON.stringify(answer.result ?? null)
     );
   }
+  const quotedMario = answer.result?.['quotedMario'];
+  const syncAttributesTxId = answer.result?.['syncAttributesTxId'];
   return {
     registryTxId,
-    quotedMario:
-      typeof body.result?.quotedMario === 'string'
-        ? body.result.quotedMario
-        : null,
+    quotedMario: typeof quotedMario === 'string' ? quotedMario : null,
     syncAttributesTxId:
-      typeof body.result?.syncAttributesTxId === 'string'
-        ? body.result.syncAttributesTxId
-        : null,
+      typeof syncAttributesTxId === 'string' ? syncAttributesTxId : null,
   };
 };
 
@@ -894,66 +889,49 @@ export class GasStationJobError extends Error {
 /** kind:5096 client seam (tests inject a stub — NEVER the live net). */
 export interface GasStationClient {
   quote(args: {
-    viaUrl: string;
+    /** Store node's ILP destination, for error messages. */
+    destination: string;
     /** Optional draft wire tx for an accurate (rent-aware) maxLamports. */
     transaction?: string;
-    nostrSecretKey: Uint8Array;
+    /** Paid transport to that node's DVM. */
+    submit: SubmitStoreJob;
   }): Promise<GasStationQuote>;
   execute(args: {
-    viaUrl: string;
+    destination: string;
     transaction: string;
     quoteId: string;
     idempotencyKey: string;
-    nostrSecretKey: Uint8Array;
+    submit: SubmitStoreJob;
   }): Promise<GasStationExecuteResult>;
 }
 
-/** POST one signed kind:5096 job to the DVM's `/store` backend. */
-async function postGasStationJob(
-  viaUrl: string,
+/**
+ * Carry one kind:5096 job to the DVM over the PAID path (#101).
+ *
+ * Same change as the buy job above, and for the same reason: `/store` is an
+ * envelope target beneath the route's handler, not a public URL path.
+ */
+async function submitGasStationJob(
+  destination: string,
   params: [string, string][],
-  nostrSecretKey: Uint8Array
+  submit: SubmitStoreJob
 ): Promise<Record<string, unknown>> {
-  const { finalizeEvent } = await import('nostr-tools/pure');
-  const event = finalizeEvent(
-    {
-      kind: GAS_STATION_JOB_KIND,
-      created_at: Math.floor(Date.now() / 1000),
-      content: '',
-      tags: params.map(([k, v]) => ['param', k, v]),
-    },
-    nostrSecretKey
-  );
-  const url = `${viaUrl.replace(/\/+$/, '')}/store`;
-  let response: Response;
+  let answer;
   try {
-    response = await fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ event }),
-    });
+    answer = await submit({ kind: GAS_STATION_JOB_KIND, params });
   } catch (err) {
     throw new GasStationJobError(
       'unreachable',
-      `could not reach the DVM at ${url}: ${err instanceof Error ? err.message : String(err)}`
+      `could not reach the DVM at ${destination}: ${err instanceof Error ? err.message : String(err)}`
     );
   }
-  let body: { accept?: boolean; code?: string; message?: string; result?: Record<string, unknown> };
-  try {
-    body = (await response.json()) as typeof body;
-  } catch {
+  if (!answer.accept || !answer.result) {
     throw new GasStationJobError(
-      'bad_response',
-      `the DVM at ${url} returned a non-JSON response (HTTP ${response.status})`
+      String(answer.code ?? 'rejected'),
+      `the DVM at ${destination} rejected the kind:${GAS_STATION_JOB_KIND} job (HTTP ${answer.status}${answer.code ? `, ${answer.code}` : ''})${answer.message ? `: ${answer.message}` : ''}`
     );
   }
-  if (!response.ok || body.accept !== true || !body.result) {
-    throw new GasStationJobError(
-      String(body.code ?? 'rejected'),
-      `the DVM rejected the kind:${GAS_STATION_JOB_KIND} job (HTTP ${response.status}${body.code ? `, ${body.code}` : ''})${body.message ? `: ${body.message}` : ''}`
-    );
-  }
-  const result = body.result;
+  const result = answer.result;
   if (result['status'] === 'failed') {
     throw new GasStationJobError(
       String(result['reason'] ?? 'failed'),
@@ -970,15 +948,15 @@ async function postGasStationJob(
  */
 export const defaultGasStationClient: GasStationClient = {
   quote: async (args) => {
-    const result = await postGasStationJob(
-      args.viaUrl,
+    const result = await submitGasStationJob(
+      args.destination,
       [
         ['phase', 'quote'],
         ...(args.transaction !== undefined
           ? ([['transaction', args.transaction]] as [string, string][])
           : []),
       ],
-      args.nostrSecretKey
+      args.submit
     );
     const { quoteId, feePayer, maxLamports, recentBlockhash, expiresAt } =
       result as Partial<GasStationQuote>;
@@ -997,15 +975,15 @@ export const defaultGasStationClient: GasStationClient = {
     return { quoteId, feePayer, maxLamports, recentBlockhash, expiresAt };
   },
   execute: async (args) => {
-    const result = await postGasStationJob(
-      args.viaUrl,
+    const result = await submitGasStationJob(
+      args.destination,
       [
         ['phase', 'execute'],
         ['transaction', args.transaction],
         ['quoteId', args.quoteId],
         ['idempotencyKey', args.idempotencyKey],
       ],
-      args.nostrSecretKey
+      args.submit
     );
     const signature = result['signature'];
     if (typeof signature !== 'string' || signature.length === 0) {
@@ -1038,10 +1016,16 @@ export interface NameDeps {
   cwd: string;
   /** ar.io SDK loader seam; defaults to the lazy `@ar.io/sdk` import. */
   loadArns?: LoadArns;
-  /** kind:5095 job submitter seam; defaults to the signed HTTP POST. */
+  /** kind:5095 job submitter seam; defaults to the paid ILP submission. */
   submitDvmBuyJob?: SubmitDvmBuyJob;
-  /** kind:5096 gas-station client seam; defaults to the signed HTTP POST. */
+  /** kind:5096 gas-station client seam; defaults to the paid ILP submission. */
   gasStation?: GasStationClient;
+  /**
+   * Standalone-session factory for the `--via` paid path (#101); defaults to
+   * `rig push`'s. Tests inject a fake so no session is ever opened and no
+   * packet is ever paid for.
+   */
+  loadStandalone?: LoadStandalone;
   /**
    * TOON-network resolution seam for the default `--via` DVM (defaults to
    * `rig fund`'s {@link resolveEffectiveNetwork}; tests inject). The devnet
@@ -1053,9 +1037,17 @@ export interface NameDeps {
 /**
  * The deployed devnet store DVM — defaulted as `--via` for buy/set when BOTH
  * the ArNS `--network` and the TOON network resolve to devnet and the user
- * neither named a DVM (`--via`/`RIG_ARNS_DVM_URL`) nor opted out (`--direct`).
+ * neither named a DVM (`--via`/`RIG_ARNS_DVM_DESTINATION`) nor opted out
+ * (`--direct`).
  */
-export const DEVNET_DVM_URL = 'https://dvm.devnet.toonprotocol.dev';
+export const DEVNET_DVM_DESTINATION = 'g.toon.ario';
+
+/**
+ * @deprecated `--via` names an ILP destination, not an HTTP endpoint (#101).
+ * Kept as an alias so an importer of the old name still compiles; it now holds
+ * the same destination as {@link DEVNET_DVM_DESTINATION}.
+ */
+export const DEVNET_DVM_URL = DEVNET_DVM_DESTINATION;
 
 export const NAME_USAGE = `Usage: rig name <buy|set|status> <name> [options]
 
@@ -1109,17 +1101,24 @@ Options:
                        unverified.
   --process-id <id>    explicit ArNS registry program id — a Solana program
                        address (overrides --network; or RIG_ARIO_PROCESS_ID)
-  --via <dvm-url>      broker buy/set through a store DVM's job endpoint (or
-                       RIG_ARNS_DVM_URL). The DVM pays the mARIO; you own the
-                       name via your spawned ANT. Direct backend targeting
-                       stubs the job payment (dev/e2e) — the paid path runs
-                       the same job through the connector payment proxy.
+  --via <destination>  broker buy/set through a store node's DVM, naming its
+                       ILP DESTINATION (or RIG_ARNS_DVM_DESTINATION), e.g.
+                       --via ${DEVNET_DVM_DESTINATION}. The DVM pays the mARIO;
+                       you own the name via your spawned ANT.
+                       The job travels as a PAID packet, exactly as a git-object
+                       store write does — the store sits behind the connector's
+                       payment termination, so there is no unpaid endpoint to
+                       aim at. That node's ingress, route price and payment
+                       channel are all discovered from its own announce, so the
+                       destination is the only thing you supply.
+                       Costs one store-route packet per job (two for set:
+                       quote + execute).
                        DEVNET DEFAULT: with --network devnet and the TOON
                        network on devnet too, buy/set default to the deployed
-                       devnet store DVM (${DEVNET_DVM_URL})
+                       devnet store DVM (${DEVNET_DVM_DESTINATION})
                        unless --direct opts out.
   --direct             force the direct wallet-paid path: never default (or
-                       read RIG_ARNS_DVM_URL as) a --via DVM. Mutually
+                       read RIG_ARNS_DVM_DESTINATION as) a --via DVM. Mutually
                        exclusive with an explicit --via.
   --yes                skip the confirmation (required when not a TTY) for
                        buy/set
@@ -1154,6 +1153,43 @@ interface NameContext {
  * `buy`/`set` escalate to `write` only at execute time, after the confirm
  * gate.
  */
+/**
+ * Open a paid session against the store node `--via` names, and hand back its
+ * job seam plus the teardown the caller must run (#101).
+ *
+ * `storeDestination` is the whole configuration this needs. From it, the
+ * machinery `rig push` already uses discovers that node's BTP ingress from its
+ * own kind:10032 announce, opens (or resumes) a payment channel against its
+ * settlement address, and reads its route price to floor the claim — the same
+ * store leg #98 built, pointed somewhere chosen per invocation.
+ *
+ * ⚠️ The caller owns the returned `stop`. A session left open holds the
+ * identity lock and an started embedded client.
+ */
+async function openStoreJobSession(
+  deps: NameDeps,
+  destination: string
+): Promise<{ submit: SubmitStoreJob; stop: () => Promise<void> }> {
+  const ctx = await (deps.loadStandalone ?? defaultLoadStandalone)({
+    env: deps.env,
+    cwd: deps.cwd,
+    warn: (line) => deps.io.err(line),
+    storeDestination: destination,
+  });
+  const submitStoreJob = ctx.publisher.submitStoreJob;
+  if (!submitStoreJob) {
+    await ctx.stop();
+    throw new Error(
+      'the active publisher cannot submit a store job (submitStoreJob ' +
+        'unavailable) — `rig name --via` requires the standalone publisher'
+    );
+  }
+  return {
+    submit: (request) => submitStoreJob.call(ctx.publisher, request),
+    stop: () => ctx.stop(),
+  };
+}
+
 async function resolveNameContext(
   deps: NameDeps,
   network: ArioNetwork,
@@ -1305,15 +1341,33 @@ function parseNameFlags(
         'wallet-paid path, --via brokers through a DVM'
     );
   }
-  // --direct beats the ambient RIG_ARNS_DVM_URL too (explicit opt-out).
+  // --direct beats the ambient env var too (explicit opt-out).
+  // `RIG_ARNS_DVM_URL` is the pre-#101 spelling, still read so an existing
+  // environment keeps working, but it now carries a destination.
   const viaRaw = values.direct
     ? undefined
-    : (values.via ?? env['RIG_ARNS_DVM_URL']);
+    : (values.via ??
+      env['RIG_ARNS_DVM_DESTINATION'] ??
+      env['RIG_ARNS_DVM_URL']);
   let via: string | undefined;
   if (viaRaw !== undefined) {
-    if (!/^https?:\/\/.+/.test(viaRaw)) {
+    // #101: `--via` names an ILP DESTINATION, not an HTTP endpoint. The store
+    // sits behind the connector's payment termination and no connector serves
+    // a public `/store`, so a URL here is a leftover from the broken direct
+    // path rather than a usable value — reject it with the fix rather than
+    // letting it fail later as an unroutable address.
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(viaRaw)) {
       throw new Error(
-        `--via must be an http(s) DVM endpoint URL, got ${JSON.stringify(viaRaw)}`
+        `--via names an ILP destination, not a URL (got ${JSON.stringify(viaRaw)}). ` +
+          `Brokered ArNS jobs travel as paid packets to a store node, e.g. ` +
+          `--via ${DEVNET_DVM_DESTINATION}. The node's endpoint, price and ` +
+          `payment channel are discovered from its own announce.`
+      );
+    }
+    if (!/^g\.[a-z0-9]+(\.[a-z0-9-]+)*$/i.test(viaRaw)) {
+      throw new Error(
+        `--via must be an ILP destination like ${DEVNET_DVM_DESTINATION}, ` +
+          `got ${JSON.stringify(viaRaw)}`
       );
     }
     via = viaRaw;
@@ -1500,16 +1554,24 @@ async function runBuy(
       io.out(`Spawned ANT ${spawn.processId} (tx ${spawn.signature})`);
     }
     // 2. Submit the kind:5095 job carrying OUR processId; the DVM executes
-    //    buyRecord with ITS funded signer.
+    //    buyRecord with ITS funded signer. The job rides a PAID ILP packet to
+    //    the store node `--via` names (#101), so a session is opened for it and
+    //    closed whatever happens — it holds the identity lock.
     const submit = deps.submitDvmBuyJob ?? defaultSubmitDvmBuyJob;
-    const receipt = await submit({
-      viaUrl: via,
-      name,
-      type,
-      years,
-      processId: spawn.processId,
-      nostrSecretKey: signed.nostrSecretKey,
-    });
+    const session = await openStoreJobSession(deps, via);
+    let receipt;
+    try {
+      receipt = await submit({
+        destination: via,
+        name,
+        type,
+        years,
+        processId: spawn.processId,
+        submit: session.submit,
+      });
+    } finally {
+      await session.stop();
+    }
     const result = {
       registryTxId: receipt.registryTxId,
       antProcessId: spawn.processId,
@@ -1756,27 +1818,37 @@ async function runSet(
     // ── Gas-station path (toon-meta#163): author + partial-sign locally,
     //    the DVM co-signs as fee payer and broadcasts. ────────────────────
     const gas = deps.gasStation ?? defaultGasStationClient;
-    // Quote: learn the fee payer + the quoted blockhash (merged deadline).
-    const quote = await gas.quote({
-      viaUrl: via,
-      nostrSecretKey: signed.nostrSecretKey,
-    });
-    // Build + partial-sign against exactly the quoted blockhash.
-    const wireTx = await signed.sdk.buildSetRecordTransaction({
-      antProcessId,
-      undername: undername ?? '@',
-      transactionId: txId,
-      ttlSeconds: flags.ttl,
-      feePayer: quote.feePayer,
-      recentBlockhash: quote.recentBlockhash,
-    });
-    const executed = await gas.execute({
-      viaUrl: via,
-      transaction: wireTx,
-      quoteId: quote.quoteId,
-      idempotencyKey: randomUUID(),
-      nostrSecretKey: signed.nostrSecretKey,
-    });
+    // Both phases ride PAID ILP packets to the store node `--via` names
+    // (#101). One session covers the pair: the quote's blockhash deadline
+    // makes re-opening between them a way to expire your own quote.
+    const session = await openStoreJobSession(deps, via);
+    let quote: GasStationQuote;
+    let executed: GasStationExecuteResult;
+    try {
+      // Quote: learn the fee payer + the quoted blockhash (merged deadline).
+      quote = await gas.quote({
+        destination: via,
+        submit: session.submit,
+      });
+      // Build + partial-sign against exactly the quoted blockhash.
+      const wireTx = await signed.sdk.buildSetRecordTransaction({
+        antProcessId,
+        undername: undername ?? '@',
+        transactionId: txId,
+        ttlSeconds: flags.ttl,
+        feePayer: quote.feePayer,
+        recentBlockhash: quote.recentBlockhash,
+      });
+      executed = await gas.execute({
+        destination: via,
+        transaction: wireTx,
+        quoteId: quote.quoteId,
+        idempotencyKey: randomUUID(),
+        submit: session.submit,
+      });
+    } finally {
+      await session.stop();
+    }
     const gasStation = {
       quoteId: quote.quoteId,
       feePayer: quote.feePayer,
@@ -2013,16 +2085,17 @@ export async function runName(args: string[], deps: NameDeps): Promise<number> {
   ) {
     let toonDevnet = false;
     try {
-      const resolved = await (deps.resolveToonNetwork ??
-        resolveEffectiveNetwork)({ env: deps.env, cwd: deps.cwd });
+      const resolved = await (
+        deps.resolveToonNetwork ?? resolveEffectiveNetwork
+      )({ env: deps.env, cwd: deps.cwd });
       toonDevnet = resolved.effectiveNetwork === 'devnet';
     } catch {
       // Unreadable client config — leave the wallet-paid path untouched.
     }
     if (toonDevnet) {
-      flags = { ...flags, via: DEVNET_DVM_URL };
+      flags = { ...flags, via: DEVNET_DVM_DESTINATION };
       io.err(
-        `Brokering via the devnet store DVM ${DEVNET_DVM_URL} ` +
+        `Brokering via the devnet store DVM ${DEVNET_DVM_DESTINATION} ` +
           `(no --via given; pass --direct for a wallet-paid ${sub}).`
       );
     }

--- a/packages/rig/src/cli/standalone-context.ts
+++ b/packages/rig/src/cli/standalone-context.ts
@@ -59,6 +59,18 @@ export interface StandaloneLoadOptions {
    */
   channelDestination?: string;
   /**
+   * Store-route override (`rig name --via`, #101): the ILP destination of the
+   * store node whose DVM should handle this command's kind:5095/5096 job,
+   * instead of the configured/announced store route.
+   *
+   * Highest precedence, above `TOON_CLIENT_STORE_DESTINATION` and the config
+   * file, because it is a per-invocation choice rather than a setting. Setting
+   * it is all a caller needs to do: the store node's BTP ingress, its route
+   * price and its own payment channel are then discovered from that node's own
+   * kind:10032 announce by the machinery `rig push` already uses (#98).
+   */
+  storeDestination?: string;
+  /**
    * When false, a missing proxy/BTP write uplink is tolerated: free reads
    * (`rig balance`) never send paid writes, so they work from a read-only
    * config. Default true (paid commands fail fast with MissingUplinkError).

--- a/packages/rig/src/cli/standalone-mode.test.ts
+++ b/packages/rig/src/cli/standalone-mode.test.ts
@@ -1365,4 +1365,50 @@ describe('resolveNetworkTopology — store leg', () => {
     );
     expect(topology.storeBtpUrl).toBe('wss://pinned.example.test/ilp/btp');
   });
+
+  // ── `rig name --via` store override (#101) ───────────────────────────────
+
+  it('a --via store override outranks the env var and the config file', async () => {
+    // Per-invocation, so it beats both settings — `--via` is a choice made for
+    // one command, not a configured default.
+    const topology = await resolveNetworkTopology(
+      inputs({
+        peers: [apexAnnounce(), storeAnnounce()],
+        env: { TOON_CLIENT_STORE_DESTINATION: 'g.env.store' },
+        file: { storeDestination: 'g.file.store' },
+        storeDestinationOverride: 'g.proxy.store',
+      })
+    );
+    expect(topology.storeDestination).toBe('g.proxy.store');
+  });
+
+  it('resolves the OVERRIDDEN node’s own uplink and price, not the payment peer’s', async () => {
+    // The whole point of pointing `--via` somewhere: that node holds its own
+    // channel, so a claim signed on the publish channel is refused (F01).
+    const topology = await resolveNetworkTopology(
+      inputs({
+        peers: [apexAnnounce(), storeAnnounce()],
+        storeDestinationOverride: 'g.proxy.store',
+      })
+    );
+    expect(topology.storeBtpUrl).toBe('wss://store.example.test/ilp/btp');
+    expect(topology.storeBtpUrl).not.toBe(topology.btpUrl);
+    expect(topology.routePrices?.store).toBe('1000');
+  });
+
+  it('warns rather than guessing when no announce claims the overridden route', async () => {
+    // Guessing an endpoint for an unadvertised destination would send real
+    // claims to a node nobody announced.
+    const warnings: string[] = [];
+    const topology = await resolveNetworkTopology(
+      inputs({
+        peers: [apexAnnounce(), storeAnnounce()],
+        storeDestinationOverride: 'g.nobody.store',
+        warn: (l) => warnings.push(l),
+      })
+    );
+    expect(topology.storeDestination).toBe('g.nobody.store');
+    expect(topology.storeBtpUrl).toBeUndefined();
+    expect(warnings.join('\n')).toContain('g.nobody.store');
+  });
 });

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -1429,14 +1429,25 @@ export async function createStandaloneContext(
     // channel is refused by it (F01) — so without a store uplink the store
     // route is unreachable, and only its own announce publishes one. Pinning
     // the publish transport says nothing about how to reach the store.
+    // A per-invocation `--via` override (#101) has to be weighed here too, or
+    // the gate answers for a store route the run will not use: a config that
+    // pins store == publish looks fully explicit, discovery is skipped, and
+    // the overridden node's announce — the only thing carrying its uplink,
+    // price and channel — is never fetched.
     const explicitStoreDest =
-      env['TOON_CLIENT_STORE_DESTINATION'] ?? file.storeDestination;
+      options.storeDestination ??
+      env['TOON_CLIENT_STORE_DESTINATION'] ??
+      file.storeDestination;
     const explicitPublishDest =
       env['TOON_CLIENT_PUBLISH_DESTINATION'] ?? file.publishDestination;
     const storeUplinkKnown =
       !explicitStoreDest ||
       explicitStoreDest === explicitPublishDest ||
-      Boolean(env['TOON_CLIENT_STORE_BTP_URL'] ?? file.storeBtpUrl);
+      // A pinned `storeBtpUrl` was pinned for whatever the CONFIG named, so it
+      // vouches for nothing once `--via` names a different node. Only a
+      // configured store route may lean on it.
+      (options.storeDestination === undefined &&
+        Boolean(env['TOON_CLIENT_STORE_BTP_URL'] ?? file.storeBtpUrl));
     const fullyExplicit =
       Boolean(
         (env['TOON_CLIENT_PROXY_URL'] ?? file.proxyUrl) ||

--- a/packages/rig/src/cli/standalone-mode.ts
+++ b/packages/rig/src/cli/standalone-mode.ts
@@ -273,6 +273,12 @@ export interface NetworkTopologyInputs {
    * degrades to the single-uplink behaviour that predates this field.
    */
   peers?: AnnouncedPeer[];
+  /**
+   * Per-invocation store-route override (`rig name --via`, #101). Wins over
+   * `TOON_CLIENT_STORE_DESTINATION` and the config file, since it is a choice
+   * made for one command rather than a configured default.
+   */
+  storeDestinationOverride?: string;
   /** The committed genesis seed entry, if any. */
   genesisSeed: GenesisSeedLike | undefined;
   identity: { mnemonic: string; accountIndex: number; pubkey: string };
@@ -521,8 +527,16 @@ function deriveSolanaChannel(
 export async function resolveNetworkTopology(
   inputs: NetworkTopologyInputs
 ): Promise<NetworkTopology> {
-  const { env, file, configPath, relayUrl, announce, genesisSeed, warn } =
-    inputs;
+  const {
+    env,
+    file,
+    configPath,
+    relayUrl,
+    announce,
+    genesisSeed,
+    warn,
+    storeDestinationOverride,
+  } = inputs;
 
   // ── Explicit config (always wins, per field) ─────────────────────────────
   const explicitProxyUrl = env['TOON_CLIENT_PROXY_URL'] ?? file.proxyUrl;
@@ -532,7 +546,9 @@ export async function resolveNetworkTopology(
   const explicitPublish =
     env['TOON_CLIENT_PUBLISH_DESTINATION'] ?? file.publishDestination;
   const explicitStore =
-    env['TOON_CLIENT_STORE_DESTINATION'] ?? file.storeDestination;
+    storeDestinationOverride ??
+    env['TOON_CLIENT_STORE_DESTINATION'] ??
+    file.storeDestination;
   const explicitChain = env['TOON_CLIENT_CHAIN'] ?? file.chain;
   const explicitMaps: ExplicitChainConfig = {
     ...(file.chainRpcUrls ? { chainRpcUrls: file.chainRpcUrls } : {}),
@@ -1470,6 +1486,9 @@ export async function createStandaloneContext(
       relayUrl,
       announce,
       ...(discoveredPeers ? { peers: discoveredPeers } : {}),
+      ...(options.storeDestination
+        ? { storeDestinationOverride: options.storeDestination }
+        : {}),
       genesisSeed,
       identity: {
         mnemonic: identity.mnemonic,

--- a/packages/rig/src/publisher.ts
+++ b/packages/rig/src/publisher.ts
@@ -84,6 +84,49 @@ export interface PublishReceipt {
 }
 
 /**
+ * One NIP-90 job for a store node's DVM, carried on the PAID path (#101).
+ *
+ * The store sits behind the connector's payment termination, so there is no
+ * public HTTP endpoint to POST these to — a reachable one would be an
+ * anonymous free gateway to a paid handler, which is the failure ADR 0020
+ * exists to close. The job therefore travels exactly as a kind:5094 store
+ * write does: inside a paid ILP packet, with `/store` as the envelope target
+ * BENEATH the route's handler path rather than as a URL path.
+ */
+export interface StoreJobRequest {
+  /** NIP-90 job kind — 5095 brokered ArNS buy, 5096 gas station. */
+  kind: number;
+  /** Job arguments, sent as `["param", key, value]` tags. */
+  params: [string, string][];
+}
+
+/**
+ * A store DVM's answer, opened from the sealed FULFILL.
+ *
+ * ⚠️ A refusal is a RESULT, not an error. Under ADR 0020 an HTTP status is
+ * envelope content and never a packet outcome, so `accept: false` arrives on a
+ * FULFILL and the payer was charged for it either way. Implementations must
+ * return it rather than throw: the zero-ARIO rehearsal (submit a buy with no
+ * `processId` and watch the handler refuse by name before it quotes or touches
+ * the registry) is the cheapest proof the whole paid path works, and it only
+ * works if the refusal comes back as data.
+ */
+export interface StoreJobResponse {
+  /** HTTP status the app answered with, inside the envelope. */
+  status: number;
+  /** The DVM's own accept flag. `false` is a refusal, not a transport fault. */
+  accept: boolean;
+  /** Machine-readable refusal reason, when the DVM sent one. */
+  code?: string;
+  /** Human-readable detail, when the DVM sent one. */
+  message?: string;
+  /** The job's output, shape depending on `kind`. */
+  result?: Record<string, unknown>;
+  /** Fee paid to carry this job, in the smallest asset unit. */
+  feePaid: bigint;
+}
+
+/**
  * Fee rates used by `planPush` for the pre-push estimate.
  *
  * Both figures are FLAT per packet. ADR 0020 (toon-client#452) removed
@@ -131,6 +174,16 @@ export interface Publisher {
    * implement it — `rig site` requires it and errors clearly when absent.
    */
   uploadBlob?(upload: BlobUpload): Promise<UploadReceipt>;
+  /**
+   * Submit one NIP-90 job to the store node's DVM over the paid path and
+   * return its answer; paid. Used by `rig name buy/set --via` (#101) for the
+   * brokered kind:5095 buy and the kind:5096 gas station.
+   *
+   * Optional for the same reason as {@link uploadBlob}: transports that only
+   * move git objects (and pre-#101 test fakes) need not implement it, and
+   * `rig name --via` errors clearly when it is absent.
+   */
+  submitStoreJob?(request: StoreJobRequest): Promise<StoreJobResponse>;
   /**
    * Sign (implementation-held key) and pay-to-publish one event to the
    * given relay(s).

--- a/packages/rig/src/standalone/standalone-publisher.test.ts
+++ b/packages/rig/src/standalone/standalone-publisher.test.ts
@@ -451,6 +451,163 @@ describe('StandalonePublisher', () => {
     });
   });
 
+  describe('submitStoreJob (brokered ArNS + gas station over the paid path, #101)', () => {
+    const buyJob = {
+      kind: 5095,
+      params: [
+        ['name', 'boughtviatoonnode'],
+        ['type', 'lease'],
+        ['years', '1'],
+        ['processId', 'ANT-PROCESS-ID'],
+      ] as [string, string][],
+    };
+
+    it('carries the job as a paid kind:5095 packet with /store beneath the handler', async () => {
+      const { client, calls } = mockClient({
+        publishResult: (event) => ({
+          success: true,
+          eventId: event.id,
+          response: storeAnswer(
+            JSON.stringify({
+              accept: true,
+              result: { registryTxId: 'REGISTRY-TX', quotedMario: '1748629680' },
+            })
+          ),
+        }),
+      });
+      const publisher = build(client, { routePrices: { store: 61000n } });
+
+      const answer = await publisher.submitStoreJob(buyJob);
+      const expectedFee = 61000n;
+      expect(answer).toEqual({
+        status: 200,
+        accept: true,
+        result: { registryTxId: 'REGISTRY-TX', quotedMario: '1748629680' },
+        feePaid: expectedFee,
+      });
+
+      // One claim, at the store route's flat price — same as a kind:5094.
+      expect(calls.claims).toEqual([
+        { channelId: 'channel-1', amount: expectedFee },
+      ]);
+      const pub = calls.publishes[0]!;
+      expect(pub.event.kind).toBe(5095);
+      expect(pub.event.content).toBe('');
+      // `param` tags, then the bid the handler reads to see the job funded.
+      expect(pub.event.tags).toEqual([
+        ['param', 'name', 'boughtviatoonnode'],
+        ['param', 'type', 'lease'],
+        ['param', 'years', '1'],
+        ['param', 'processId', 'ANT-PROCESS-ID'],
+        ['bid', expectedFee.toString(), 'usdc'],
+      ]);
+      // The whole point of #101: `/store` as the envelope target beneath the
+      // route's handler path, NOT a public URL path.
+      expect(pub.options?.destination).toBe('g.proxy.store');
+      expect(pub.options?.proxyPath).toBe('/store');
+      expect(pub.options?.ilpAmount).toBe(expectedFee);
+      await publisher.stop();
+    });
+
+    it('returns a DVM refusal as DATA rather than throwing (the zero-ARIO rehearsal)', async () => {
+      // Omitting `processId` makes the handler refuse BY NAME before it quotes
+      // or touches the registry. That is the cheapest proof the whole paid path
+      // works, and it only works if the refusal comes back as a value. Under
+      // ADR 0020 the payer was charged either way, so `feePaid` still reports.
+      const { client, calls } = mockClient({
+        publishResult: (event) => ({
+          success: true,
+          eventId: event.id,
+          response: storeAnswer(
+            JSON.stringify({
+              accept: false,
+              code: 'MISSING_PARAM',
+              message: 'missing required param tag: processId',
+            }),
+            422
+          ),
+        }),
+      });
+      const publisher = build(client, { routePrices: { store: 1000n } });
+
+      const answer = await publisher.submitStoreJob({
+        kind: 5095,
+        params: [['name', 'boughtviatoonnode']],
+      });
+      expect(answer).toEqual({
+        status: 422,
+        accept: false,
+        code: 'MISSING_PARAM',
+        message: 'missing required param tag: processId',
+        feePaid: 1000n,
+      });
+      expect(calls.claims).toHaveLength(1);
+      await publisher.stop();
+    });
+
+    it('throws when the packet never reached the store', async () => {
+      const { client } = mockClient({
+        publishResult: () => ({ success: false, error: 'F01 - claim rejected' }),
+      });
+      const publisher = build(client, { routePrices: { store: 1000n } });
+      await expect(publisher.submitStoreJob(buyJob)).rejects.toThrow(
+        /kind:5095 job rejected: F01/
+      );
+      await publisher.stop();
+    });
+
+    it('throws when a FULFILL carries no sealed answer', async () => {
+      const { client } = mockClient({
+        publishResult: (event) => ({ success: true, eventId: event.id }),
+      });
+      const publisher = build(client, { routePrices: { store: 1000n } });
+      await expect(publisher.submitStoreJob(buyJob)).rejects.toThrow(
+        /carried no sealed response/
+      );
+      await publisher.stop();
+    });
+
+    it('throws with the body when the answer is not JSON', async () => {
+      const { client } = mockClient({
+        publishResult: (event) => ({
+          success: true,
+          eventId: event.id,
+          response: storeAnswer('<html>502 Bad Gateway</html>', 502),
+        }),
+      });
+      const publisher = build(client, { routePrices: { store: 1000n } });
+      await expect(publisher.submitStoreJob(buyJob)).rejects.toThrow(
+        /was not valid JSON \(HTTP 502\)/
+      );
+      await publisher.stop();
+    });
+
+    it('carries a kind:5096 gas-station job the same way', async () => {
+      const { client, calls } = mockClient({
+        publishResult: (event) => ({
+          success: true,
+          eventId: event.id,
+          response: storeAnswer(
+            JSON.stringify({ accept: true, result: { quoteId: 'quote-1' } })
+          ),
+        }),
+      });
+      const publisher = build(client, { routePrices: { store: 1000n } });
+      const answer = await publisher.submitStoreJob({
+        kind: 5096,
+        params: [['phase', 'quote']],
+      });
+      expect(answer.accept).toBe(true);
+      expect(calls.publishes[0]!.event.kind).toBe(5096);
+      expect(calls.publishes[0]!.event.tags).toEqual([
+        ['param', 'phase', 'quote'],
+        ['bid', '1000', 'usdc'],
+      ]);
+      expect(calls.publishes[0]!.options?.proxyPath).toBe('/store');
+      await publisher.stop();
+    });
+  });
+
   describe('flat route pricing (the connector gates packets at the route price — F06)', () => {
     const gitUpload = (bytes: number) => ({
       sha: '1234567890abcdef1234567890abcdef12345678',

--- a/packages/rig/src/standalone/standalone-publisher.test.ts
+++ b/packages/rig/src/standalone/standalone-publisher.test.ts
@@ -490,7 +490,8 @@ describe('StandalonePublisher', () => {
       expect(calls.claims).toEqual([
         { channelId: 'channel-1', amount: expectedFee },
       ]);
-      const pub = calls.publishes[0]!;
+      const [pub] = calls.publishes;
+      if (!pub) throw new Error('expected exactly one paid publish');
       expect(pub.event.kind).toBe(5095);
       expect(pub.event.content).toBe('');
       // `param` tags, then the bid the handler reads to see the job funded.
@@ -598,12 +599,14 @@ describe('StandalonePublisher', () => {
         params: [['phase', 'quote']],
       });
       expect(answer.accept).toBe(true);
-      expect(calls.publishes[0]!.event.kind).toBe(5096);
-      expect(calls.publishes[0]!.event.tags).toEqual([
+      const [pub] = calls.publishes;
+      if (!pub) throw new Error('expected exactly one paid publish');
+      expect(pub.event.kind).toBe(5096);
+      expect(pub.event.tags).toEqual([
         ['param', 'phase', 'quote'],
         ['bid', '1000', 'usdc'],
       ]);
-      expect(calls.publishes[0]!.options?.proxyPath).toBe('/store');
+      expect(pub.options?.proxyPath).toBe('/store');
       await publisher.stop();
     });
   });

--- a/packages/rig/src/standalone/standalone-publisher.ts
+++ b/packages/rig/src/standalone/standalone-publisher.ts
@@ -46,6 +46,8 @@ import {
   type GitObjectUpload,
   type PublishReceipt,
   type Publisher,
+  type StoreJobRequest,
+  type StoreJobResponse,
   type UploadReceipt,
 } from '../publisher.js';
 import {
@@ -1220,6 +1222,87 @@ export class StandalonePublisher implements Publisher {
       );
     }
     return { txId: extractArweaveTxId(result.response), feePaid: fee };
+  }
+
+  /**
+   * Submit one NIP-90 job (kind:5095 brokered ArNS buy, kind:5096 gas station)
+   * to the store node's DVM over the PAID path, and return its answer (#101).
+   *
+   * Identical carriage to {@link uploadGitObject}: the store leg's own channel,
+   * one balance-proof claim for the store route's flat price, and `/store` as
+   * the envelope target beneath the route's handler path. What differs is only
+   * the event body — `["param", k, v]` tags instead of `["i", ...]` inputs.
+   *
+   * The `bid` tag carries the same figure as the claim. It is what the handler
+   * reads to decide the job was funded, and a mismatch between it and the claim
+   * is the kind of thing that gets a packet refused after it has already been
+   * charged for (connector#869).
+   *
+   * ⚠️ Does NOT throw on a DVM refusal. `accept: false` and a non-2xx status
+   * are envelope content, not packet outcomes (ADR 0020) — the answer arrived
+   * and the payer was charged — so both come back as data for the caller to
+   * interpret. Only the absence of an answer is an error here.
+   */
+  async submitStoreJob(request: StoreJobRequest): Promise<StoreJobResponse> {
+    await this.start();
+    const leg = await this.storeLeg();
+
+    const fee = this.uploadFee();
+    const event = leg.client.signEvent({
+      kind: request.kind,
+      content: '',
+      created_at: nowSeconds(),
+      tags: [
+        ...request.params.map(([key, value]) => ['param', key, value]),
+        ['bid', fee.toString(), 'usdc'],
+      ],
+    });
+
+    const claim = await leg.client.signBalanceProof(leg.channelId, fee);
+    const result = await leg.client.publishEvent(event, {
+      ...(this.storeDestination ? { destination: this.storeDestination } : {}),
+      claim,
+      ilpAmount: fee,
+      // The store backend serves POST /store (not the relay's /write).
+      proxyPath: '/store',
+    });
+    if (!result.success) {
+      throw new StandalonePublishError(
+        `kind:${request.kind} job rejected: ${result.error ?? 'the packet did not reach the store'}`
+      );
+    }
+    if (!result.response) {
+      throw new StandalonePublishError(
+        `kind:${request.kind} job FULFILL carried no sealed response; expected the DVM's answer`
+      );
+    }
+
+    const text = new TextDecoder().decode(result.response.body);
+    let body: {
+      accept?: unknown;
+      code?: unknown;
+      message?: unknown;
+      result?: unknown;
+    };
+    try {
+      body = JSON.parse(text) as typeof body;
+    } catch {
+      throw new StandalonePublishError(
+        `kind:${request.kind} job answer was not valid JSON ` +
+          `(HTTP ${result.response.status}): ${JSON.stringify(text.slice(0, 200))}`
+      );
+    }
+
+    return {
+      status: result.response.status,
+      accept: body.accept === true,
+      ...(typeof body.code === 'string' ? { code: body.code } : {}),
+      ...(typeof body.message === 'string' ? { message: body.message } : {}),
+      ...(body.result !== null && typeof body.result === 'object'
+        ? { result: body.result as Record<string, unknown> }
+        : {}),
+      feePaid: fee,
+    };
   }
 
   /**


### PR DESCRIPTION
Fixes #101.

`rig name buy --via` and `rig name set --via` did a raw `fetch(${viaUrl}/store)`. No connector serves `/store`, so the brokered ArNS path could not work for anyone. Re-measured on 3.6.0 while writing this:

| endpoint | `/store` | `/ilp` |
|---|---|---|
| `dvm.devnet.toonprotocol.dev` (the documented default) | connection refused | connection refused |
| a third-party node's edge | 404 | 400 |
| `proxy.ario.devnet.toonprotocol.dev` | 404 | 400 |

## The endpoint should stay absent

That is the part worth agreeing on before the code. "Make connectors serve `/store`" is the tempting reading and I think it is the wrong one: the store sits behind the connector's payment termination, so a publicly reachable `/store` would be an unpaid path to a paid handler. ADR 0020 names that failure directly:

> the failure mode of an unpriced connector in front of a payment-oblivious app, an anonymous free gateway to that app, which is what #492 discovered

So `--via` changes meaning instead. It now names an **ILP destination**, and the job rides a paid packet with `/store` as the envelope target beneath the route's handler path.

## This is a bypassed capability, not a new one

`defaultSubmitDvmBuyJob`'s own docstring already described the correct path:

> on the paid path the identical event travels inside a paid ILP packet and the connector in front of the DVM replays this same HTTP request after terminating payment (RouteTermination), so the job shape is one and the same

And the transport was already in the same package, shipping, for kind:5094 git-object writes. The kind:5095/5096 `param` tags are unchanged, so the handler sees the identical event either way.

## What changed

- **`Publisher` gains an optional `submitStoreJob`**, following `uploadBlob`'s optional-method pattern. It returns a DVM refusal as **data rather than throwing**: under ADR 0020 `accept: false` arrives on a FULFILL and the payer was charged either way, and the zero-ARIO rehearsal (submit a buy with no `processId`, watch the handler refuse by name before it quotes or touches the registry) is the cheapest proof the whole paid path works. It only works if the refusal is a value.
- **`StandalonePublisher.submitStoreJob`** mirrors `uploadGitObject`: the store leg's own channel, one claim at the store route's flat price, a `bid` tag carrying that same figure, `proxyPath: '/store'`.
- **`StandaloneLoadOptions` gains `storeDestination`**, at highest precedence over `TOON_CLIENT_STORE_DESTINATION` and the config file, since it is a per-invocation choice rather than a setting. **This is the whole of the wiring.** #98 already made the store leg discover its BTP ingress, route price and payment channel from the store node's own kind:10032 announce, so pointing it somewhere is all `--via` has to do.
- A **URL in `--via` is rejected** with the destination form in the error, rather than failing later as an unroutable address. That matters because a URL means the caller still expects the old direct path.
- `RIG_ARNS_DVM_DESTINATION` is the env spelling. `RIG_ARNS_DVM_URL` is still read so an existing environment keeps working, and `DEVNET_DVM_URL` stays exported as an alias.

Two lifecycle details that are easy to get wrong:

- Sessions are closed in a `finally`. They hold the identity lock, so leaking one wedges the next command.
- `set` opens **one** session covering both gas-station phases. Re-opening between quote and execute risks expiring the quote's own blockhash deadline.
- A pure estimate (`--json` without `--yes`) opens **none**. A session costs an on-chain channel against the store node.

## Verification

- **10 tests added.** 4 session-lifecycle in `name.test.ts` (right destination, closed on the failure path too, one session for both `set` phases, none for an estimate) and 6 transport in `standalone-publisher.test.ts` (exact event shape including the bid tag and `proxyPath`, refusal-as-data, a rejected packet, a FULFILL with no answer, a non-JSON answer, kind:5096).
- **Full suite 1041 passing, up from 1031 on `main`.** Both have the same 4 pre-existing failures: 2 in `init.test.ts` and 2 from `@ar.io/sdk`'s missing `opossum` transitive dep. I confirmed those by stashing and re-running rather than assuming.
- Typecheck clean. Lint 0 errors. `format:check` returns to its baseline count.

## What this does NOT prove

**Not verified end to end against a live node.** kind:5096 is off on the only third-party node available (it needs a separate SOL-only fee payer per toon-meta#163), so the gas-station seam has unit coverage only. The kind:5095 seam can be exercised for one packet with the zero-ARIO rehearsal against a node that has 5095 enabled, and I am happy to run that against a live devnet DVM if one is up and someone tells me where.

Note connector#869 charges a rejected packet in full, so the rehearsal is cheap rather than free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
