### PR TITLE
ci: the changeset gate must parse a changeset, not just count files (port of toon-client#611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,44 @@ jobs:
             fi
           fi
 
+      # The step above asserts only that a `.changeset/*.md` FILE EXISTS. It
+      # never parses one, so a changeset that is well-formed YAML but an invalid
+      # RELEASE PLAN passes it, and `release.yml` — which runs after merge, where
+      # its failure gates nothing — is the first thing to read the file.
+      #
+      # toon-client had the byte-identical job, and that is exactly what happened
+      # there (toon-client#611): a changeset naming both `@toon-protocol/client`
+      # and the `ignore`d `@toon-protocol/client-mcp` merged, `changeset version`
+      # refuses a changeset that mixes ignored and non-ignored packages, and
+      # `release.yml` was red on EVERY push to main for a day — so no fix could
+      # reach npm. Because `changeset version` stops at the first offender, FIVE
+      # such changesets had piled up behind that error before anyone looked.
+      #
+      # This repo has the same shape and the same exposure:
+      # `.changeset/config.json` lists `@toon-protocol/rig-web` in `ignore`, so
+      # one hand-written changeset naming both it and `@toon-protocol/rig` would
+      # wedge releases here the same way. Nothing is wrong today — both pending
+      # changesets name only `@toon-protocol/rig` — so this is the guard ported
+      # BEFORE it is needed rather than after.
+      #
+      # `changeset version` rather than `changeset status`: it is the
+      # byte-identical command `release.yml`'s `changesets/action` runs as its
+      # `version:` input, so green here means the release gets past versioning,
+      # with no second implementation to drift. `status` additionally resolves
+      # `baseBranch` through git and errors when IT decides packages changed with
+      # no changeset — duplicating the step above with a different definition of
+      # "changed". Mutating the tree is free: this job is a throwaway checkout
+      # that commits, pushes and publishes nothing, and has no later steps.
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Assert the changesets form a valid release plan
+        run: |
+          set -euo pipefail
+          pnpm changeset version
+          echo "--- the release plan this PR would produce ---"
+          git --no-pager diff --stat
+          echo "✅ changeset version succeeds — release.yml can get past versioning"
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ported from toon-protocol/toon-client#612, which fixed the same hole after it cost that repo a full day of releases.

## The hole

This repo's `changeset` job asserts exactly one thing: that a PR touching `packages/rig` **adds a `.changeset/*.md` file**.

```sh
new_changesets=$(echo "$changed" | grep -c "^\.changeset/.*\.md$" || true)
if [ "$new_changesets" -eq 0 ]; then
  echo "::error::This PR modifies a publishable package but includes no changeset."
```

It never opens the file. So a changeset that is well-formed YAML but an **invalid release plan** passes the gate, and `release.yml` — which runs after merge, where its failure gates nothing and looks like every other post-merge red — is the first thing in the repo to read it.

## Why this is not hypothetical

toon-client had the byte-identical job. toon-client#611: a changeset naming both `@toon-protocol/client` and the `ignore`d `@toon-protocol/client-mcp` merged. Changesets refuses a changeset that mixes ignored and non-ignored packages — it cannot decide whether the release plan includes it — and that refusal is a hard error out of `changeset version`. `release.yml` went red on **every** push to `main` for a day, so a stack of correctness fixes sat unpublishable. And because `changeset version` stops at the **first** offender, **five** such changesets had piled up behind that one error before anyone looked; fixing only the file named in the error would just have uncovered the next.

This repo has the same shape and the same exposure. `.changeset/config.json`:

```json
"ignore": ["@toon-protocol/rig-web"]
```

One hand-written changeset naming both `@toon-protocol/rig-web` and `@toon-protocol/rig` wedges releases here identically. **Nothing is wrong today** — both pending changesets (`brokered-arns-over-paid-ilp.md`, `channel-map-counterparty-validation.md`) name only `@toon-protocol/rig`, and `release.yml`'s last five runs on `main` are all green. This is the guard ported *before* it is needed rather than after.

## The fix

The existing file-exists step is kept — it is a different duty and it works — and a real assertion is added after it:

```yaml
- uses: ./.github/actions/setup-workspace

- name: Assert the changesets form a valid release plan
  run: |
    set -euo pipefail
    pnpm changeset version
    ...
```

**`changeset version`, not `changeset status`.** Fidelity: this is the byte-identical command `release.yml`'s `changesets/action` runs as its `version:` input, so a green check means *the release will get past versioning*, with no second implementation to drift out of sync. `status` is read-only and prettier, but it additionally resolves `baseBranch` through git and exits 1 when **it** decides packages changed with no changeset — duplicating the step above with a different definition of "changed" and a new way to misfire.

Mutating the tree costs nothing: this job is a throwaway checkout that commits, pushes and publishes nothing and has no later steps, so the bumps are printed rather than discarded (`git diff --stat` makes "which packages would this release move" visible on every PR).

`setup-workspace` is the repo's existing composite action, so this reuses the same pinned pnpm 8.15.9 + Node 22 + `--no-frozen-lockfile` install as `build`.

## Verified locally

In a clean worktree off `origin/main`:

| tree | `pnpm changeset version` |
|---|---|
| as-is | **exit 0** — `All files have been updated`, bumps `@toon-protocol/rig` |
| plus a changeset naming `@toon-protocol/rig` **and** `@toon-protocol/rig-web` | **exit 1** — `🦋 error Error: Found mixed changeset` / `Found ignored packages: @toon-protocol/rig-web` |

toon-client#612 also has a real CI run of the equivalent step going red on a reintroduced mixed changeset ([run 32035358198](https://github.com/toon-protocol/toon-client/actions/runs/32035358198): `Changeset check` fail, `CI OK` fail, every other job green).

## Wiring

None needed — `changeset` is already in `ci-ok`'s `needs:` list and `ci-ok` already fails explicitly when `needs.changeset.result != success` on a `pull_request`. This PR does not publish anything and does not touch `packages/`.
