### PR TITLE
The README hands users a Solana mint whose authority is lost

### DIFF
--- a/.changeset/solana-mint-422.md
+++ b/.changeset/solana-mint-422.md
@@ -1,0 +1,10 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Re-pin the devnet Solana mock-USDC mint in the settlement-contracts table.
+
+The README's `solana:devnet` row named `xyc5J8MgKFiEN13PnfftdXxUzYH34FEvw1LCrFwN7in`,
+whose mint authority is lost — nobody can mint it, and the faucet cannot drip it. The
+live devnet settlement token is `34eSxY7qxQ4GzyhDJ8GpUcTz1WWzruGbJbR8q6TtxfQU`
+(connector#1212). Documentation only.

--- a/packages/rig/README.md
+++ b/packages/rig/README.md
@@ -381,7 +381,7 @@ Chain ids below are the **announced spellings** — use them verbatim with
 | Chain (`TOON_CLIENT_CHAIN`) | Payment-channel contract/program/zkApp | USDC token (6dp) | Explorer |
 |---|---|---|---|
 | `evm:84532` (Base Sepolia) | TokenNetwork `0x1E95493fEF46707E034b4a1945f25a8C76A1823D` (registry `0xcC9079adE929b168B54145f6d25262b64FAB9D5b`) | `0x49beE1Bca5d15Fb0963117923403F9498119a9Ce` | [base-sepolia.blockscout.com](https://base-sepolia.blockscout.com) |
-| `solana:devnet` | program `2aEVJ8koKD8LTZrLRSGtAtU7LBt4e7QjjCgf1kzQ7Rip` | mint `xyc5J8MgKFiEN13PnfftdXxUzYH34FEvw1LCrFwN7in` | [explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet) |
+| `solana:devnet` | program `2aEVJ8koKD8LTZrLRSGtAtU7LBt4e7QjjCgf1kzQ7Rip` | mint `34eSxY7qxQ4GzyhDJ8GpUcTz1WWzruGbJbR8q6TtxfQU` | [explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet) |
 | `mina:devnet` | PaymentChannel zkApp `B62qmgPhv2Xo6QVEtwjLja8UZJUtu8yapRFAR6gaoGtbM9zE5hG7Tkf` | token `B62qqN1Pu3kF2KGmqLA8EwpqfWrnFTVZJGDSDHQuQRoVt5BCFjhNz3d`<br>tokenId `9497120696276615621907376728658022802954262638363646162765282600447713419198` | [minascan.io/devnet](https://minascan.io/devnet/home) |
 
 ### Config notes (rig ≥ 2.10.2)


### PR DESCRIPTION
`packages/rig/README.md`'s settlement-contracts table is copy-paste material: it exists so a user can pin `TOON_CLIENT_CHAIN=solana:devnet` and know which token their channel settles in.

Its `solana:devnet` row named `xyc5J8MgKFiEN13PnfftdXxUzYH34FEvw1LCrFwN7in`, which is **retired** — still on chain with its 100M supply, but its mint authority was only ever in a scratchpad that is gone. Nobody can mint it, and the faucet cannot drip it. A user following the table funds nothing and gets no error that says why.

Re-pinned to `34eSxY7qxQ4GzyhDJ8GpUcTz1WWzruGbJbR8q6TtxfQU` — the mint the faucet box is itself the authority of and mints on demand (connector#1212) — matching the canonical source, `connector`'s `infra/linode/endpoints.json` → `solana.tokenMint`.

Documentation only; the changeset is a patch because CI requires one for any `packages/rig/` change.

### Noted, not fixed here

The same table's `evm:84532` row is also stale against `endpoints.json`: it names TokenNetwork `0x1E95493fEF46707E034b4a1945f25a8C76A1823D` and registry `0xcC9079adE929b168B54145f6d25262b64FAB9D5b`, where the canonical file now says registry `0x0c41D9D424d6B075A3cEa1068a694f7847a8CCa5` and TokenNetwork `0xe9E05dfecfe165266C88d73e61D483612651952a` (the ADR 0059 cutover, 2026-08-28). That is a separate re-pin from toon-meta#422's Solana one and is left for its own change rather than smuggled in here.

Part of toon-protocol/toon-meta#422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zXF3foMadEMEg9UgYimWW