### PR TITLE
fix(release): unwedge npm publishing — an ignored-only changeset blocked every release

### DIFF
--- a/.changeset/mainnet-gateway-defaults.md
+++ b/.changeset/mainnet-gateway-defaults.md
@@ -1,5 +1,0 @@
----
-'@toon-protocol/rig-web': patch
----
-
-Default the ArNS result URL and the pointer-page asset gateway to mainnet ar.io gateways. `ar-io.dev` is ar.io's testnet gateway (its ArNS resolver runs against the Solana devnet contracts), so a mainnet name printed as `https://<name>.ar-io.dev/` was a guaranteed 404. `RIG_ARNS_GATEWAY` still overrides.

--- a/packages/rig-web/CHANGELOG.md
+++ b/packages/rig-web/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @toon-protocol/rig
 
+## Unreleased
+
+This package is `private` and listed in `ignore` in `.changeset/config.json`, so
+`changeset version` never bumps it and never writes to this file. Entries below
+this heading are recorded by hand; a changeset file is NOT the way to note a
+rig-web change, because an `ignore`d-only changeset is inert and blocks releases
+of `@toon-protocol/rig` (see the changeset gate in `.github/workflows/ci.yml`).
+
+- Default the ArNS result URL and the pointer-page asset gateway to mainnet
+  ar.io gateways. `ar-io.dev` is ar.io's testnet gateway (its ArNS resolver runs
+  against the Solana devnet contracts), so a mainnet name printed as
+  `https://<name>.ar-io.dev/` was a guaranteed 404. `RIG_ARNS_GATEWAY` still
+  overrides. (Shipped in #104.)
+
 ## 0.2.46
 
 ### Patch Changes


### PR DESCRIPTION
## The symptom

`@toon-protocol/rig` is **4.0.0 on main and 3.6.0 on npm**. 4.0.0 was versioned by `Version Packages (#107)` and never published, and no release since has published either — so every fix on main since 2026-09-05 is unreachable to users, including the whole 4.0 connector cutover.

The `Release` run for #107 ([34034253613](https://github.com/toon-protocol/rig/actions/runs/34034253613)) failed:

```
HttpError: Validation Failed: {"resource":"PullRequest","code":"custom",
"message":"No commits between main and changeset-release/main"}
```

and the follow-on `Smoke-test published rig` run was consequently `skipped`.

## The cause

`.changeset/mainnet-gateway-defaults.md` names only `@toon-protocol/rig-web`, which `.changeset/config.json` lists in `ignore`. On such a changeset `changeset version` **exits 0, produces no release plan, and leaves the file in place** — so it is never consumed. Reproduced against `@changesets/cli@2.27.9`:

```
$ cat .changeset/x.md         # '@toon-protocol/rig-web': patch
$ changeset version; echo $?  # 🦋  All files have been updated.  ->  0
$ git diff --stat             # (empty)
$ ls .changeset/              # config.json   x.md      <- still there
```

`changesets/action` publishes **only when no changeset is pending**. With that file sitting on main permanently, every push to main takes the version-PR branch instead of the publish branch, then fails to open a PR that has no commits in it. It is a self-perpetuating block: the changeset is never consumed, so it never stops happening.

## How it got past CI

PR #104 touched `packages/rig-web/**` **and** `packages/rig/README.md`. The `Require changeset` step saw the `packages/rig` change and **demanded** a changeset; the author wrote one for the package they were actually changing, `rig-web`; and the `Assert the changesets form a valid release plan` step ran `changeset version`, got exit 0, and passed it green.

The gate was ported for the *mixed* ignored/non-ignored case, where `changeset version` exits **non-zero**. This is the neighbouring case where it exits **zero**.

## This PR

Removes the inert changeset. main is then left with no pending changeset, so the next push to main takes the publish path and **4.0.0 reaches npm**.

#104's user-facing note is preserved by hand in `packages/rig-web/CHANGELOG.md` — which `changeset version` never writes to, rig-web being private and ignored — together with a note on why a changeset file is the wrong way to record a rig-web change.

## Follow-up

The gate change that stops this recurring (assert that every changeset a PR *adds* is *consumed* by `changeset version`) is written and tested but needs the `workflow` OAuth scope to push; it follows in a separate PR.

## Verification after merge

- `Release` run goes green and takes the **publish** path, not the version-PR path
- `npm view @toon-protocol/rig version` → `4.0.0`
- the `Smoke-test published rig` run fires (instead of `skipped`) and passes

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWo2GU9cSQPvRYb7tCpxYm