### PR TITLE
fix: the post-release smoke job, plus two pieces of 4.0-stale documentation

### DIFF
--- a/.changeset/entry-help-and-faucet-row.md
+++ b/.changeset/entry-help-and-faucet-row.md
@@ -1,0 +1,17 @@
+---
+'@toon-protocol/rig': patch
+---
+
+Correct two pieces of shipped documentation that 4.0.0 left behind
+
+- `rig --help` still advertised `entry [apex|sandbox|url]`, describing the
+  `apex` and `sandbox` presets and the topology cache that #116 removed.
+  `rig entry apex` has exited non-zero with `unknown entry "apex" — expected a
+  connector http(s):// URL or 'clear'` since 4.0.0, so the primary help screen
+  documented a path that cannot work. It now describes the real shape:
+  `rig entry <connector-url>` / `rig entry clear`, plus `--relay <wss-url>`.
+- The devnet faucet table listed `POST /api/solana/request` ("2 SOL + 1000
+  USDC"). That route is gone — it answers **404**, while the two routes above
+  it answer 400 on a bad address, i.e. they still exist. `rig fund` only ever
+  called the two USDC-only routes, so this was a stale row rather than a
+  broken code path. Removed.

--- a/packages/rig/README.md
+++ b/packages/rig/README.md
@@ -411,7 +411,6 @@ Faucet routes (`POST`, body `{"address": "<wallet>"}`):
 |---|---|
 | `/api/base-sepolia/request` | 1000 USDC (ungated on-chain mint) + best-effort Base Sepolia gas |
 | `/api/solana/usdc-request` | 1000 USDC (treasury transfer, no SOL leg) |
-| `/api/solana/request` | 2 SOL + 1000 USDC (airdrop leg subject to the public devnet's per-IP quota) |
 
 `rig fund` hits the two USDC-only routes for the identity's derived wallets —
 it funds USDC and assumes gas is already present.

--- a/packages/rig/src/cli/dispatch.ts
+++ b/packages/rig/src/cli/dispatch.ts
@@ -94,10 +94,11 @@ Commands rig owns:
                              (free — chain reads and local state only)
   chain [set <c>|unset]      choose which chain/USDC settles paid writes
                              (evm|sol|mina); free — reads/writes local config
-  entry [apex|sandbox|url]   choose the network entry node (payment ingress +
-                             relay): apex settles evm|sol|mina, sandbox is the
-                             Mina-only multihop demo path; free — writes local
-                             config and clears the cached topology
+  entry <url> | entry clear  choose the connector that prices and settles paid
+                             writes — one URL is the whole configuration, since
+                             its GET /ilp describes it; --relay <wss-url>
+                             records the free-read relay beside it; free —
+                             writes local config
   name buy <name>            ArNS naming (#367): buy points a human name at an
   name set <name> <txId>     Arweave txId, owned + paid by this identity's
   name status <name>         Solana key. buy spends mARIO on Solana via the

--- a/scripts/smoke-published/smoke-published.mjs
+++ b/scripts/smoke-published/smoke-published.mjs
@@ -36,6 +36,22 @@ export const TEST_MNEMONIC =
 export const DEFAULT_ARNS_NAME = 'ardrive';
 export const DEFAULT_DEVNET_RELAY = 'wss://relay-ws.devnet.toonprotocol.dev';
 
+// A connector URL is MANDATORY as of 4.0.0. #116 removed the `apex`/`sandbox`
+// presets and the genesis-seed/topology discovery rig used to bootstrap from,
+// so `site publish` now aborts locally — before any I/O — with:
+//
+//   no connector configured: set TOON_CONNECTOR to the node's URL (the one
+//   whose GET /ilp describes it), run `rig entry <url>`, or add connectorUrl
+//   to <home>/.toon-client/config.json
+//
+// This script predates that change (untouched since 2026-07-24) and set no
+// connector, so it failed deterministically against any 4.x build for a reason
+// having nothing to do with the published artifact. Since it runs automatically
+// on `workflow_run: Release`, that turned every release red.
+//
+// This is the shared devnet relay node documented at README.md:93 and :398.
+export const DEFAULT_CONNECTOR = 'https://proxy.relay.devnet.toonprotocol.dev';
+
 // ---------------------------------------------------------------------------
 // Pure validators (unit-tested in smoke-published.test.mjs)
 // ---------------------------------------------------------------------------
@@ -241,7 +257,17 @@ export function main(env = process.env, log = console.log) {
   const rigBin = env.RIG_BIN ?? 'rig';
   const arnsName = env.SMOKE_ARNS_NAME ?? DEFAULT_ARNS_NAME;
   const relayUrl = env.SMOKE_DEVNET_RELAY ?? DEFAULT_DEVNET_RELAY;
-  const identityEnv = { ...env, RIG_MNEMONIC: TEST_MNEMONIC };
+  // An explicit TOON_CONNECTOR in the environment wins, then SMOKE_CONNECTOR,
+  // then the documented devnet node — so a maintainer can point the smoke run
+  // at another node without editing this file.
+  const connectorUrl =
+    env.TOON_CONNECTOR ?? env.SMOKE_CONNECTOR ?? DEFAULT_CONNECTOR;
+  const identityEnv = {
+    ...env,
+    RIG_MNEMONIC: TEST_MNEMONIC,
+    TOON_CONNECTOR: connectorUrl,
+  };
+  log(`using connector ${connectorUrl}`);
 
   const results = [];
   checkHelp(rigBin, log, results, 'name');


### PR DESCRIPTION
Found while verifying the 4.0.0 release. None of this touches the write path.

## 1. The post-release smoke job fails deterministically (the one that matters)

`scripts/smoke-published/smoke-published.mjs` runs automatically on `workflow_run: Release`, so it has been going red on **every** release for a reason unrelated to the artifact's health.

It has been untouched since 2026-07-24, before #116. It does `rig init` + `rig remote add origin <relay>` and never configures a connector — which 4.0.0 made **mandatory** when it removed the `apex`/`sandbox` presets and the genesis-seed/topology discovery rig used to bootstrap from. `site publish` therefore aborts locally, before any I/O:

```
no connector configured: set TOON_CONNECTOR to the node's URL (the one whose
GET /ilp describes it), run `rig entry <url>`, or add connectorUrl to ...
```

**Verified against the 4.0.0 artifact actually published to npm today**, installed fresh in a clean directory:

| | result |
|---|---|
| script as it stands on main | `1/4 smoke checks FAILED` |
| script with this fix | `4/4 smoke checks passed` |

The passing run hits **live mainnet ar.io** for `name status ardrive` (the #376 packaged-module-graph pin) and the **live devnet connector** for the `site publish` estimate.

Precedence is `TOON_CONNECTOR` (already in the environment) → `SMOKE_CONNECTOR` → the documented devnet node at `README.md:93`, so a maintainer can retarget the run without editing this file.

## 2. `rig --help` documents removed presets

`dispatch.ts` advertised `entry [apex|sandbox|url]`, describing `apex`, `sandbox` and the topology cache that #116 deleted. `rig entry apex` has been refused since 4.0.0:

```
unknown entry "apex" — expected a connector http(s):// URL or `clear`
```

So the primary help screen documented a path that cannot work. Now describes the real shape.

## 3. A dead faucet row

The devnet faucet table listed `POST /api/solana/request` ("2 SOL + 1000 USDC"). Probed today:

```
POST /api/base-sepolia/request  -> 400   (exists, rejects a bad address)
POST /api/solana/usdc-request   -> 400   (exists, rejects a bad address)
POST /api/solana/request        -> 404   (gone)
```

`rig fund` only ever called the two USDC-only routes, so this was a stale row rather than a broken code path.

## Checks run locally

- `smoke-published.test.mjs` — 12/12 pass
- `dispatch.test.ts` — 32/32 pass
- `tsc --noEmit` — clean
- correctness gate — `eslint 0e/218w, typecheck 0e (baseline: 0e/220w, 0e)` PASSED

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWo2GU9cSQPvRYb7tCpxYm