### PR TITLE
ci: the changeset gate must reject an INERT changeset, not just an invalid one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,39 @@ jobs:
       # This repo has the same shape and the same exposure:
       # `.changeset/config.json` lists `@toon-protocol/rig-web` in `ignore`, so
       # one hand-written changeset naming both it and `@toon-protocol/rig` would
-      # wedge releases here the same way. Nothing is wrong today — both pending
-      # changesets name only `@toon-protocol/rig` — so this is the guard ported
-      # BEFORE it is needed rather than after.
+      # wedge releases here the same way.
+      #
+      # That guard was ported for the MIXED case, where `changeset version`
+      # EXITS NON-ZERO and this step catches it. The case that actually wedged
+      # this repo is the neighbouring one it does not catch: a changeset naming
+      # ONLY `ignore`d packages. There `changeset version` exits 0, writes no
+      # plan, and LEAVES THE FILE IN PLACE — so it is never consumed:
+      #
+      #   $ cat .changeset/x.md        # '@toon-protocol/rig-web': patch
+      #   $ changeset version; echo $? # 🦋 All files have been updated.  -> 0
+      #   $ git diff --stat            # (empty)
+      #   $ ls .changeset/             # config.json  x.md   <- still there
+      #
+      # PR #104 did exactly this. It touched `packages/rig-web/**` AND
+      # `packages/rig/README.md`, so the step above DEMANDED a changeset; the
+      # author wrote one for the package they were really changing, rig-web,
+      # which is `ignore`d. This step ran `changeset version`, got exit 0, and
+      # passed it green. After merge the file sat on main forever, and because
+      # `changesets/action` publishes only when NO changeset is pending, every
+      # subsequent push to main took the version-PR branch instead, then failed
+      # to open a PR with no commits in it:
+      #
+      #   HttpError: Validation Failed: No commits between main and
+      #   changeset-release/main
+      #
+      # So `Version Packages (#107)` merged, bumping rig to 4.0.0, and 4.0.0
+      # was never published — npm stayed on 3.6.0 with main four versions
+      # ahead, and no later fix could reach npm either.
+      #
+      # Hence the second assertion below: a changeset this PR ADDS must be
+      # CONSUMED by `changeset version`. That is the precise tell — a changeset
+      # that survives versioning is inert, and an inert changeset on main is a
+      # permanent publish block, not a no-op.
       #
       # `changeset version` rather than `changeset status`: it is the
       # byte-identical command `release.yml`'s `changesets/action` runs as its
@@ -70,10 +100,38 @@ jobs:
       - name: Assert the changesets form a valid release plan
         run: |
           set -euo pipefail
+
+          # Record the changesets THIS PR adds, before the tree is mutated.
+          added=$(git diff --name-only --diff-filter=A \
+                    "origin/${{ github.base_ref }}...HEAD" -- '.changeset/*.md' || true)
+
           pnpm changeset version
           echo "--- the release plan this PR would produce ---"
           git --no-pager diff --stat
-          echo "✅ changeset version succeeds — release.yml can get past versioning"
+
+          # Every changeset this PR adds must have been CONSUMED (deleted) by
+          # `changeset version`. One that survives names only `ignore`d or
+          # otherwise unversionable packages: it produces no release plan, is
+          # never consumed, and once on main it blocks EVERY subsequent publish.
+          survivors=
+          for f in $added; do
+            [ -e "$f" ] && survivors="$survivors $f"
+          done
+
+          if [ -n "$survivors" ]; then
+            echo "::error::Inert changeset —$survivors survived 'changeset version', so it will never be consumed."
+            echo
+            echo "A changeset naming only packages in the 'ignore' list of .changeset/config.json"
+            echo "(currently: @toon-protocol/rig-web) produces no version bump. It stays on main"
+            echo "forever, and changesets/action publishes ONLY when no changeset is pending — so"
+            echo "it permanently blocks releases to npm. This is what happened in PR #104."
+            echo
+            echo "Fix: name a publishable package (@toon-protocol/rig) in the changeset, or drop"
+            echo "the changeset entirely if this PR genuinely changes nothing that ships to npm."
+            exit 1
+          fi
+
+          echo "✅ changeset version succeeds and consumes every changeset this PR adds"
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is the guard for the failure that took npm four versions behind main today. Without it, the identical wedge can happen again.

## What happened

`.changeset/mainnet-gateway-defaults.md` named only `@toon-protocol/rig-web`, which `.changeset/config.json` lists in `ignore`. On such a changeset `changeset version` **exits 0**, writes no plan, and **leaves the file in place** — so it is never consumed. Reproduced against `@changesets/cli@2.27.9`:

```
$ cat .changeset/x.md         # '@toon-protocol/rig-web': patch
$ changeset version; echo $?  # 🦋  All files have been updated.  ->  0
$ git diff --stat             # (empty)
$ ls .changeset/              # config.json   x.md      <- still there
```

`changesets/action` publishes **only when no changeset is pending**, so that one file sent every push to main down the version-PR branch instead of the publish branch, where it died opening a PR with no commits in it:

```
HttpError: Validation Failed: No commits between main and changeset-release/main
```

Self-perpetuating — never consumed, so it never stopped. `Version Packages (#107)` merged, bumping rig to 4.0.0, and **4.0.0 was never published**.

## Why the existing gate missed it

The gate was ported for the **mixed** ignored/non-ignored case, where `changeset version` exits **non-zero** and the step catches it. This is the neighbouring case, where it exits **zero** — the step ran, got 0, and passed it green.

It reached main because PR #104 touched `packages/rig-web/**` *and* `packages/rig/README.md`: the `Require changeset` step **demanded** a changeset for the rig change, and the author wrote one for the package they were really changing.

## The guard

Every changeset a PR **adds** must be **consumed** by `changeset version`. A changeset that survives versioning is inert, and an inert changeset on main is a permanent publish block, not a no-op.

Verified against `@changesets/cli@2.27.9` on a fixture matching this repo's config:

| case | result |
|---|---|
| changeset naming only the `ignore`d package (the #104 bug) | **BLOCKED** |
| normal `@toon-protocol/rig` changeset | allowed |
| docs-only PR with no changeset | allowed |

The error message names the actual cause and the fix, rather than leaving the next person to rediscover it after the fact.

## Note

This PR touches only `.github/workflows/ci.yml`, so it needs no changeset — and the gate's own `Changeset check` run on this PR exercises the new code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWo2GU9cSQPvRYb7tCpxYm