### PR TITLE
chore: configure rig for the mattpocock engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,17 @@ TOON Protocol's git-to-TOON write path (`@toon-protocol/rig`, CLI) and its decen
 
 ## Agent skills
 
+### Workflow
+
+Planning is done by a human at the keyboard: `/wayfinder` (when what to build is still unclear) or `/grill-with-docs` (when the design is solid and needs ADRs and glossary written), then `/to-spec`, then `/to-tickets` with each ticket added as a sub-issue of the spec issue. Only after that does an agent drive the spec issue to completion with `/implement`. No one-shot prompts for features.
+
 ### Issue tracker
 
 Issues and specs are GitHub issues in `toon-protocol/rig`, driven with the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-The five triage roles map onto the existing Sandcastle labels: `ready-for-agent` is `agent:implement` (which starts a factory run) and `ready-for-human` is `needs:human`; `needs-triage` and `needs-info` are new. See `docs/agents/triage-labels.md`.
+The five default triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), kept separate from the Sandcastle factory labels so a triage decision never starts a factory run. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# rig
+
+TOON Protocol's git-to-TOON write path (`@toon-protocol/rig`, CLI) and its decentralized control-plane frontend (`@toon-protocol/rig-web`). A push pays a TOON connector over ILP; objects land on Arweave via the store, and NIP-34 events land on the relay. Protocol truth lives in `toon-protocol/connector` (`docs/protocol/`, `docs/adr/`), not here.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs are GitHub issues in `toon-protocol/rig`, driven with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five triage roles map onto the existing Sandcastle labels: `ready-for-agent` is `agent:implement` (which starts a factory run) and `ready-for-human` is `needs:human`; `needs-triage` and `needs-info` are new. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` at the root plus `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## Layout: single-context
+
+rig is a pnpm workspace with two packages (`packages/rig`, the CLI, and `packages/rig-web`, the frontend) that ship one product, so it is documented as a single context:
+
+```
+/
+├── CONTEXT.md                 (created lazily by /domain-modeling)
+├── docs/adr/
+│   └── 0001-rig-web-ownership-and-url-permanence.md
+└── packages/
+    ├── rig/
+    └── rig-web/
+```
+
+Protocol-level decisions live upstream in `toon-protocol/connector` under `docs/adr/` and `docs/protocol/`; rig ADRs record decisions about rig itself. When a rig change depends on a connector ADR, cite it by number.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (rig-web ownership), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues in `toon-protocol/rig`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,18 +2,16 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-rig already carries the Sandcastle factory vocabulary (`docs/factory-runbook.md`, toon-meta `FACTORY.md`): `agent:implement` is a trigger label that starts a factory run and opens a PR, and `needs:human` marks work that needs a person. The mapping below reuses those rather than adding parallel labels, so a triage decision and a factory trigger are the same action.
-
-| Label in mattpocock/skills | Label in our tracker | Meaning                                                                        |
-| -------------------------- | -------------------- | ------------------------------------------------------------------------------ |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue                                        |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information                                       |
-| `ready-for-agent`          | `agent:implement`    | Fully specified, ready for an AFK agent. Applying it STARTS a Sandcastle run.  |
-| `ready-for-human`          | `needs:human`        | Requires human implementation or a human decision                              |
-| `wontfix`                  | `wontfix`            | Will not be actioned                                                           |
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Category roles map to the stock GitHub labels: `bug` and `enhancement`.
 
-`needs-triage` and `needs-info` do not exist in the repo yet; create them once with `gh label create`. `agent:review` and `agent:fix` are factory labels for PRs, outside the triage machine.
+These are deliberately separate from the Sandcastle factory labels (`agent:implement`, `agent:review`, `agent:fix`, `needs:human`; see `docs/factory-runbook.md`). `ready-for-agent` means a ticket is fully specified and a developer's own agent session may pick it up with `/implement`. It never starts a factory run; only a human applying `agent:implement` does that.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,19 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+rig already carries the Sandcastle factory vocabulary (`docs/factory-runbook.md`, toon-meta `FACTORY.md`): `agent:implement` is a trigger label that starts a factory run and opens a PR, and `needs:human` marks work that needs a person. The mapping below reuses those rather than adding parallel labels, so a triage decision and a factory trigger are the same action.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                                                        |
+| -------------------------- | -------------------- | ------------------------------------------------------------------------------ |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue                                        |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information                                       |
+| `ready-for-agent`          | `agent:implement`    | Fully specified, ready for an AFK agent. Applying it STARTS a Sandcastle run.  |
+| `ready-for-human`          | `needs:human`        | Requires human implementation or a human decision                              |
+| `wontfix`                  | `wontfix`            | Will not be actioned                                                           |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Category roles map to the stock GitHub labels: `bug` and `enhancement`.
+
+`needs-triage` and `needs-info` do not exist in the repo yet; create them once with `gh label create`. `agent:review` and `agent:fix` are factory labels for PRs, outside the triage machine.


### PR DESCRIPTION
Per-repo config that the \`mattpocock-skills\` plugin's engineering skills read (\`/triage\`, \`/to-spec\`, \`/to-tickets\`, \`/implement\`), following the workflow Jonathan set out on 2026-09-06.

- \`CLAUDE.md\` (new; every other TOON repo uses CLAUDE.md, none has AGENTS.md): a one-paragraph description of rig plus the \`## Agent skills\` block, including the human-driven planning flow (\`/wayfinder\` or \`/grill-with-docs\` → \`/to-spec\` → \`/to-tickets\` as sub-issues → \`/implement\`).
- \`docs/agents/issue-tracker.md\`: GitHub via \`gh\`. PRs as a request surface: off.
- \`docs/agents/triage-labels.md\`: the five plugin defaults (\`needs-triage\`, \`needs-info\`, \`ready-for-agent\`, \`ready-for-human\`, \`wontfix\`), deliberately separate from the Sandcastle labels so \`ready-for-agent\` never starts a factory run. The two missing labels still need \`gh label create\`.
- \`docs/agents/domain.md\`: single-context (root \`CONTEXT.md\`, created lazily, plus the existing \`docs/adr/\`). Protocol decisions stay in \`connector\`.

Docs and config only, no code. Written by hand following the \`setup-matt-pocock-skills\` process; re-running that skill after merge is harmless and will pick these files up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)